### PR TITLE
feat: add PWA support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+public/serviceWorker.js

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap"
           rel="stylesheet"
         ></link>
-        <script src="/serviceWorker.js"></script>
+        <script src="/serviceWorker.js" async></script>
       </head>
       <body>{children}</body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap"
           rel="stylesheet"
         ></link>
-        <script src="/serviceWorker.js" async></script>
+        <script src="/serviceWorkerRegister.js" defer></script>
       </head>
       <body>{children}</body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,6 +50,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap"
           rel="stylesheet"
         ></link>
+        <script src="/serviceWorker.js"></script>
       </head>
       <body>{children}</body>
     </html>

--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -9,7 +9,6 @@ self.addEventListener('install', function (event) {
     caches.open(CHATGPT_NEXT_WEB_CACHE)
       .then(function (cache) {
         return cache.addAll([
-          '/',
         ]);
       })
   );
@@ -23,13 +22,3 @@ self.addEventListener('fetch', function (event) {
       })
   );
 });
-
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', function () {
-    navigator.serviceWorker.register('/serviceWorker.js').then(function (registration) {
-      console.log('ServiceWorker registration successful with scope: ', registration.scope);
-    }, function (err) {
-      console.error('ServiceWorker registration failed: ', err);
-    });
-  });
-}

--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -1,0 +1,35 @@
+const CHATGPT_NEXT_WEB_CACHE = "chatgpt-next-web-cache";
+
+self.addEventListener('activate', function (event) {
+  console.log('ServiceWorker activated.');
+});
+
+self.addEventListener('install', function (event) {
+  event.waitUntil(
+    caches.open(CHATGPT_NEXT_WEB_CACHE)
+      .then(function (cache) {
+        return cache.addAll([
+          '/',
+        ]);
+      })
+  );
+});
+
+self.addEventListener('fetch', function (event) {
+  event.respondWith(
+    caches.match(event.request)
+      .then(function (response) {
+        return response || fetch(event.request);
+      })
+  );
+});
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/serviceWorker.js').then(function (registration) {
+      console.log('ServiceWorker registration successful with scope: ', registration.scope);
+    }, function (err) {
+      console.error('ServiceWorker registration failed: ', err);
+    });
+  });
+}

--- a/public/serviceWorkerRegister.js
+++ b/public/serviceWorkerRegister.js
@@ -1,0 +1,9 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker.register('/serviceWorker.js').then(function (registration) {
+      console.log('ServiceWorker registration successful with scope: ', registration.scope);
+    }, function (err) {
+      console.error('ServiceWorker registration failed: ', err);
+    });
+  });
+}

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,21 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+    "name": "ChatGPT Next Web",
+    "short_name": "ChatGPT",
+    "icons": [
+      {
+        "src": "/android-chrome-192x192.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      },
+      {
+        "src": "/android-chrome-512x512.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      }
+    ],
+    "start_url": "/",
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
+    "display": "standalone"
+  }
+  


### PR DESCRIPTION
增加PWA支持，使ChatGPT-Next-Web可以作为PWA应用“添加到主屏幕”。
<img width="955" alt="image" src="https://user-images.githubusercontent.com/5004964/227913214-c93e8b7a-5081-43b3-a266-5a44df58b47c.png">
