### PR TITLE
fix: code copy button position

### DIFF
--- a/app/styles/markdown.scss
+++ b/app/styles/markdown.scss
@@ -839,7 +839,7 @@
 
 .markdown-body .highlight pre,
 .markdown-body pre {
-  padding: 16px;
+  padding: 16px 16px 8px 16px;
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
@@ -849,11 +849,11 @@
 
 .markdown-body pre code,
 .markdown-body pre tt {
-  display: inline;
-  max-width: auto;
+  display: inline-block;
+  max-width: 100%;
   padding: 0;
   margin: 0;
-  overflow: visible;
+  overflow-x: scroll;
   line-height: inherit;
   word-wrap: normal;
   background-color: transparent;


### PR DESCRIPTION
解决代码太长时”copy“按钮随横向滚动条移动的问题。
修复后，”copy“按钮固定在右上角，不随横向滚动条移动。

**BEFORE:**
<img width="475" alt="image" src="https://user-images.githubusercontent.com/5004964/228116006-02f811fd-e415-43c0-b855-d2607c34a607.png">


**AFTER:**
<img width="461" alt="image" src="https://user-images.githubusercontent.com/5004964/228115735-dd956cdc-db23-43c2-b275-23ad9cd34e0a.png">

