### PR TITLE
supports the display of line breaks in Markdown

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -128,7 +128,7 @@ function useSubmitHandler() {
 
   const shouldSubmit = (e: KeyboardEvent) => {
     if (e.key !== "Enter") return false;
-
+ 
     return (
       (config.submitKey === SubmitKey.AltEnter && e.altKey) ||
       (config.submitKey === SubmitKey.CtrlEnter && e.ctrlKey) ||

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -34,6 +34,7 @@ export function Markdown(props: { content: string }) {
       components={{
         pre: PreCode,
       }}
+      className="line-break"
     >
       {props.content}
     </ReactMarkdown>

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -17,7 +17,7 @@ const cn = {
       Retry: "重试",
     },
     Typing: "正在输入…",
-    Input: (submitKey: string) => `输入消息，${submitKey} 发送`,
+    Input: (submitKey: string) => `输入消息，${submitKey} 发送, Shift + Enter 换行`,
     Send: "发送",
   },
   Export: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -1,3 +1,5 @@
+import { SubmitKey } from "../store/app";
+
 const cn = {
   WIP: "该功能仍在开发中……",
   Error: {
@@ -17,7 +19,13 @@ const cn = {
       Retry: "重试",
     },
     Typing: "正在输入…",
-    Input: (submitKey: string) => `输入消息，${submitKey} 发送, Shift + Enter 换行`,
+    Input: (submitKey: string) => {
+      var inputHints = `输入消息，${submitKey} 发送`;
+      if (submitKey === String(SubmitKey.Enter)) {
+        inputHints += ", Shift + Enter 换行";
+      }
+      return inputHints;
+    },
     Send: "发送",
   },
   Export: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -20,8 +20,7 @@ const en: LocaleType = {
       Retry: "Retry",
     },
     Typing: "Typing…",
-    Input: (submitKey: string) =>
-      `Type something and press ${submitKey} to send`,
+    Input: (submitKey: string) => `Type something and press ${submitKey} to send, press Shift + Enter to newline`,
     Send: "Send",
   },
   Export: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -1,3 +1,4 @@
+import { SubmitKey } from "../store/app";
 import type { LocaleType } from "./index";
 
 const en: LocaleType = {
@@ -20,7 +21,13 @@ const en: LocaleType = {
       Retry: "Retry",
     },
     Typing: "Typing…",
-    Input: (submitKey: string) => `Type something and press ${submitKey} to send, press Shift + Enter to newline`,
+    Input: (submitKey: string) => {
+      var inputHints = `Type something and press ${submitKey} to send`;
+      if (submitKey === String(SubmitKey.Enter)) {
+        inputHints += ", press Shift + Enter to newline";
+      }
+      return inputHints;
+    },
     Send: "Send",
   },
   Export: {

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -1,3 +1,4 @@
+import { SubmitKey } from "../store/app";
 import type { LocaleType } from "./index";
 
 const tw: LocaleType = {
@@ -19,7 +20,13 @@ const tw: LocaleType = {
       Retry: "重試",
     },
     Typing: "正在輸入…",
-    Input: (submitKey: string) => `輸入訊息後，按下 ${submitKey} 鍵即可發送, Shift + Enter 鍵換行`,
+    Input: (submitKey: string) =>  {
+      var inputHints = `輸入訊息後，按下 ${submitKey} 鍵即可發送`;
+      if (submitKey === String(SubmitKey.Enter)) {
+        inputHints += ", Shift + Enter 鍵換行";
+      }
+      return inputHints;
+    },
     Send: "發送",
   },
   Export: {

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -19,7 +19,7 @@ const tw: LocaleType = {
       Retry: "重試",
     },
     Typing: "正在輸入…",
-    Input: (submitKey: string) => `輸入訊息後，按下 ${submitKey} 鍵即可發送`,
+    Input: (submitKey: string) => `輸入訊息後，按下 ${submitKey} 鍵即可發送, Shift + Enter 鍵換行`,
     Send: "發送",
   },
   Export: {

--- a/app/styles/markdown.scss
+++ b/app/styles/markdown.scss
@@ -1117,3 +1117,6 @@
 .markdown-body ::-webkit-calendar-picker-indicator {
   filter: invert(50%);
 }
+.markdown-body .line-break {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
在Enter发送模式下，使用Meta+Enter对文本进行换行。并使ReactMarkdown组件正常显示换行符