### PR TITLE
style(chat-body): fix chat-body margin-bottom not enough

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -218,7 +218,7 @@
   flex: 1;
   overflow: auto;
   padding: 20px;
-  margin-bottom: 100px;
+  margin-bottom: 160px;
 }
 
 .chat-message {


### PR DESCRIPTION
主要是修复 chat-body 底部部分被遮挡的样式问题，增加 padding-bottom 到输入框的高度 - 20 ,这个是20时输入框的 padding-top

<img width="940" alt="Snipaste_2023-03-30_00-47-40" src="https://user-images.githubusercontent.com/36723264/228614185-daf835c9-1fe1-4e5a-ac02-ce91cb7f0e4a.png">
<img width="1006" alt="Snipaste_2023-03-30_00-49-30" src="https://user-images.githubusercontent.com/36723264/228614208-d2c29177-6659-44c9-ad5e-ff300389d856.png">
