### PR TITLE
feat: import remark-breaks plugin

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from "react-markdown";
 import "katex/dist/katex.min.css";
 import RemarkMath from "remark-math";
+import RemarkBreaks from "remark-breaks";
 import RehypeKatex from "rehype-katex";
 import RemarkGfm from "remark-gfm";
 import RehypePrsim from "rehype-prism-plus";
@@ -29,7 +30,7 @@ export function PreCode(props: { children: any }) {
 export function Markdown(props: { content: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[RemarkMath, RemarkGfm]}
+      remarkPlugins={[RemarkMath, RemarkGfm, RemarkBreaks]}
       rehypePlugins={[RehypeKatex, [RehypePrsim, { ignoreMissing: true }]]}
       components={{
         pre: PreCode,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.5",
+    "remark-breaks": "^3.0.2",
     "rehype-katex": "^6.0.2",
     "rehype-prism-plus": "^1.5.1",
     "remark-gfm": "^3.0.1",


### PR DESCRIPTION
引入remark-breaks 插件解决 ReactMarkdown 组件不渲染换行问题，同时避免了底部边距问题 #162 