### PR TITLE
修复在移动端高度被搜索栏占用导致无法完整显示一屏问题

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -218,7 +218,6 @@
   flex: 1;
   overflow: auto;
   padding: 20px;
-  margin-bottom: 100px;
 }
 
 .chat-body-title {
@@ -342,9 +341,6 @@
 }
 
 .chat-input-panel {
-  position: absolute;
-  bottom: 0px;
-  display: flex;
   width: 100%;
   padding: 20px;
   box-sizing: border-box;

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -53,7 +53,7 @@
   --sidebar-width: 300px;
   --window-content-width: calc(100% - var(--sidebar-width));
   --message-max-width: 80%;
-  --full-height: 100vh;
+  --full-height: 100%;
 }
 
 @media only screen and (max-width: 600px) {
@@ -74,6 +74,9 @@
   :root {
     @include dark;
   }
+}
+html {
+  height: var(--full-height);
 }
 
 body {


### PR DESCRIPTION
Fixes #235
![image](https://user-images.githubusercontent.com/38354472/229107558-1fce57a4-4eb7-4bc7-a30d-4bbecc87efac.png)
![image](https://user-images.githubusercontent.com/38354472/229107585-07967f35-77d5-41d8-979d-fbb0ffd11449.png)
