### PR TITLE
Update docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
           images: yidadaa/chatgpt-next-web
           tags: |
             type=raw,value=latest
-            type=semver,pattern={{version}}
+            type=ref,event=tag
       
       - 
         name: Set up QEMU


### PR DESCRIPTION
release 的时候 tag 为 vx.x不符合`semver`，导致该标签的 image 不会 push 到 dockerhub
See:
https://hub.docker.com/r/yidadaa/chatgpt-next-web/tags
https://github.com/Yidadaa/ChatGPT-Next-Web/actions/runs/4567486567
此pr解决了该问题。