### PR TITLE
style: optimize the height of textarea when bluring on mobile

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -422,6 +422,11 @@
 @media only screen and (max-width: 600px) {
   .chat-input {
     font-size: 16px;
+    height: 25px;
+
+    &:focus {
+      height: auto;
+    }
   }
 }
 


### PR DESCRIPTION
> Optimize the height of textarea when bluring on mobile, and restore height again when focusing. 
> This will make the chat list has more height so that we could see more contents.

|  before  |  after  |
|  ------  |  -----  |
| ![chat1](https://user-images.githubusercontent.com/30711792/229250637-6fa549dd-8993-4555-9364-c11a87e25829.png) | ![chat2](https://user-images.githubusercontent.com/30711792/229250665-e180ffc0-7aa8-4601-991a-12ca7c2cbd18.png) |
