### PR TITLE
ci: update sync action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,16 +1,29 @@
-# .github/workflows/sync.yml
-name: Sync Fork
+name: Upstream Sync
 
 on:
-    schedule:
-        - cron: "0 8 * * *" # 每天0点触发
+  schedule:
+    - cron: '0 */12 * * *' # every 12 hours
+  workflow_dispatch: # on button click
+
 jobs:
-    repo-sync:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: TG908/fork-sync@v1.1
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }} # 这个 token action 会默认配置, 这里只需这样写就行
-                  owner: Yidadaa # fork 上游项目 owner
-                  head: main # fork 上游项目需要同步的分支
-                  base: main # 需要同步到本项目的目标分支
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+
+    steps:
+    # Step 1: run a standard checkout action, provided by github
+    - name: Checkout target repo
+      uses: actions/checkout@v3
+
+    # Step 2: run the sync action
+    - name: Sync upstream changes
+      id: sync
+      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+      with:
+        upstream_sync_repo: Yidadaa/ChatGPT-Next-Web
+        upstream_sync_branch: main
+        target_sync_branch: main
+        target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
+        
+        # Set test_mode true to run tests instead of the true action!!
+        test_mode: false


### PR DESCRIPTION
之前的同步代码有问题，因为`TG908/fork-sync@v1.1`已经不存在了。已经修复了这个问题并经过了测试，但是还有几个隐含的问题：

1.在同步后，相对于上游仓库会多一个提交记录，这会导致版本检测时使用领先一个提交的版本号；

![p1](https://user-images.githubusercontent.com/25226871/229288385-4c04eb1b-eff6-49ec-9581-988c9bf12f18.png)
![p2](https://user-images.githubusercontent.com/25226871/229288417-1c16de94-94d3-44db-af39-d82315389301.png)

2.默认生成的`GITHUB_TOKEN`没有更新workflow配置文件的权限，这意味着如果上游仓库中的其他的workflow配置文件(如:docker.yml)发生更新，下游仓库不能同步这些更新。

解决方法有两种：

- 在下游仓库中创建一个拥有`workflow`权限的`PAT`(下游用户需要进行两个额外的配置操作，增加上手成本)；
- 遇到workflow配置文件更新的情况，手动仓库页面进行更新(其他的非workflow配置文件更新可以无感同步更新)。

![p3](https://user-images.githubusercontent.com/25226871/229288163-219a132c-ecd5-4ba1-af85-dc3fda707ff3.png)
