### PR TITLE
fix: #331 修复中文输入法状态enter下submit问题

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -134,7 +134,7 @@ function useSubmitHandler() {
 
   const shouldSubmit = (e: KeyboardEvent) => {
     if (e.key !== "Enter") return false;
-
+    if (e.key === 'Enter' && !e.isComposing) return false
     return (
       (config.submitKey === SubmitKey.AltEnter && e.altKey) ||
       (config.submitKey === SubmitKey.CtrlEnter && e.ctrlKey) ||


### PR DESCRIPTION
增加判断用户是否正在使用组合输入法（例如中文输入法）进行输入。一般而言，组合输入法会在用户输入完整的拼音或者其他输入后，才会进行最终的结果输出.
修复后,如果在中文输入法打字的时候,按下enter,表示选择当前的词语而不是向chatgpt发送请求.这样符合用户的习惯