### PR TITLE
Fix: Chinese input method "Enter" issue

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -340,6 +340,15 @@ export function Chat(props: {
       }
     }, 500);
   });
+  
+  // Fix Chinese input method "Enter" issue
+  document.addEventListener(
+    "keydown",
+    (e) => {
+      if (e.keyCode == 229) e.stopPropagation();
+    },
+    true,
+  );
 
   return (
     <div className={styles.chat} key={session.id}>


### PR DESCRIPTION
中文输入法里打英文，直接按下Enter会直接发送出去，修复这个错误。

但如果[通过 `e.isComposing` 去判断](https://github.com/Yidadaa/ChatGPT-Next-Web/pull/328/files)，在 Safari 上并不兼容，因此直接全局阻止在中文输入法状态下的 Enter 的事件就可以了。 这样做没有任何副作用，因为无论是什么输入法，在输入状态 Enter 本来就不应与页面发生交互。

参考在另一个 ChatGPT 项目  ：https://github.com/lencx/ChatGPT/issues/369#issuecomment-1429313208