### PR TITLE
optimize mobile experience

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -144,8 +144,10 @@
   }
 }
 
-.chat-item:hover {
-  background-color: var(--hover-color);
+@media only screen and (min-width: 600px) {
+  .chat-item:hover {
+    background-color: var(--hover-color);
+  }
 }
 
 .chat-item-selected {
@@ -168,6 +170,13 @@
   right: -20px;
   transition: all ease 0.3s;
   opacity: 0;
+}
+
+@media only screen and (max-width: 600px) {
+  .chat-item-delete {
+    right: 10px;
+    opacity: 0.5;
+  }
 }
 
 .chat-item:hover > .chat-item-delete {
@@ -422,6 +431,7 @@
 @media only screen and (max-width: 600px) {
   .chat-input {
     font-size: 16px;
+    padding: 10px 5px;
   }
 }
 

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -431,7 +431,7 @@
 @media only screen and (max-width: 600px) {
   .chat-input {
     font-size: 16px;
-    padding: 10px 5px;
+    padding: 10px 55px 10px 10px;
   }
 }
 

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -108,7 +108,7 @@ export function ChatList() {
       state.currentSessionIndex,
       state.selectSession,
       state.removeSession,
-    ]
+    ],
   );
 
   return (
@@ -202,7 +202,7 @@ export function Chat(props: {
       setPromptHints(promptStore.search(text));
     },
     100,
-    { leading: true, trailing: true }
+    { leading: true, trailing: true },
   );
 
   const onPromptSelect = (prompt: Prompt) => {
@@ -216,7 +216,7 @@ export function Chat(props: {
     if (!dom) return;
     const paddingBottomNum: number = parseInt(
       window.getComputedStyle(dom).paddingBottom,
-      10
+      10,
     );
     dom.scrollTop = dom.scrollHeight - dom.offsetHeight + paddingBottomNum;
   };
@@ -246,7 +246,7 @@ export function Chat(props: {
     chatStore.onUserInput(userInput).then(() => setIsLoading(false));
     setUserInput("");
     setPromptHints([]);
-    inputRef.current?.focus();
+    if (!isMobileScreen()) inputRef.current?.focus();
   };
 
   // stop response
@@ -290,6 +290,7 @@ export function Chat(props: {
 
   // for auto-scroll
   const latestMessageRef = useRef<HTMLDivElement>(null);
+  const dialogBoxRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
   // preview messages
@@ -304,7 +305,7 @@ export function Chat(props: {
               preview: true,
             },
           ]
-        : []
+        : [],
     )
     .concat(
       userInput.length > 0
@@ -316,7 +317,7 @@ export function Chat(props: {
               preview: true,
             },
           ]
-        : []
+        : [],
     );
 
   // auto scroll
@@ -324,6 +325,7 @@ export function Chat(props: {
     setTimeout(() => {
       const dom = latestMessageRef.current;
       const inputDom = inputRef.current;
+      const dialogBox = dialogBoxRef.current!;
 
       // only scroll when input overlaped message body
       let shouldScroll = true;
@@ -334,8 +336,9 @@ export function Chat(props: {
       }
 
       if (dom && autoScroll && shouldScroll) {
-        dom.scrollIntoView({
-          block: "end",
+        console.log(dialogBox.scrollHeight, dialogBox.clientHeight);
+        dialogBox.scrollTo({
+          top: dialogBox.scrollHeight - dialogBox.clientHeight,
         });
       }
     }, 500);
@@ -354,7 +357,7 @@ export function Chat(props: {
               const newTopic = prompt(Locale.Chat.Rename, session.topic);
               if (newTopic && newTopic !== session.topic) {
                 chatStore.updateCurrentSession(
-                  (session) => (session.topic = newTopic!)
+                  (session) => (session.topic = newTopic!),
                 );
               }
             }}
@@ -397,7 +400,7 @@ export function Chat(props: {
         </div>
       </div>
 
-      <div className={styles["chat-body"]}>
+      <div className={styles["chat-body"]} ref={dialogBoxRef}>
         {messages.map((message, i) => {
           const isUser = message.role === "user";
 
@@ -445,8 +448,7 @@ export function Chat(props: {
                         </div>
                       </div>
                     )}
-                  {(message.preview || message.content.length === 0) &&
-                  !isUser ? (
+                  {message.preview || message.content.length === 0 ? (
                     <LoadingIcon />
                   ) : (
                     <div
@@ -484,21 +486,21 @@ export function Chat(props: {
           <textarea
             ref={inputRef}
             className={styles["chat-input"]}
-            placeholder={Locale.Chat.Input(submitKey)}
-            rows={4}
+            placeholder={isMobileScreen() ? "" : Locale.Chat.Input(submitKey)}
+            rows={isMobileScreen() ? 2 : 4}
             onInput={(e) => onInput(e.currentTarget.value)}
             value={userInput}
             onKeyDown={(e) => onInputKeyDown(e as any)}
             onFocus={() => setAutoScroll(true)}
             onBlur={() => {
-              setAutoScroll(false);
+              if (!isMobileScreen()) setAutoScroll(false);
               setTimeout(() => setPromptHints([]), 500);
             }}
             autoFocus={!props?.sideBarShowing}
           />
           <IconButton
             icon={<SendWhiteIcon />}
-            text={Locale.Chat.Send}
+            text={isMobileScreen() ? "" : Locale.Chat.Send}
             className={styles["chat-input-send"] + " no-dark"}
             onClick={onUserSubmit}
           />
@@ -603,7 +605,7 @@ export function Home() {
       state.newSession,
       state.currentSessionIndex,
       state.removeSession,
-    ]
+    ],
   );
   const loading = !useHasHydrated();
   const [showSideBar, setShowSideBar] = useState(true);
@@ -651,16 +653,6 @@ export function Home() {
 
         <div className={styles["sidebar-tail"]}>
           <div className={styles["sidebar-actions"]}>
-            <div className={styles["sidebar-action"] + " " + styles.mobile}>
-              <IconButton
-                icon={<CloseIcon />}
-                onClick={() => {
-                  if (confirm(Locale.Home.DeleteChat)) {
-                    removeSession(currentIndex);
-                  }
-                }}
-              />
-            </div>
             <div className={styles["sidebar-action"]}>
               <IconButton
                 icon={<SettingsIcon />}


### PR DESCRIPTION
优化移动端体验，有以下几点修改：

- 移动端 chat list 点击一下即可进入对话界面。之前是要点击两下，第一下是 focus，第二下才是进入，很容易令人困惑。
- 移动端 chat list 里每个 item 直接显示x删除按钮，不需要 focus 才显示。也去掉了底部的X按钮。
- fix 输入文字时，右边的聊天气泡也会同步显示文字，改为了显示`LoadingIcon`。（不知道是否是有意设计还是bug，但真的很容易困惑，给几个朋友用都第一眼以为消息发出去了）
- fix 会话界面滚动条 bug。之前在移动端下，输入键盘弹出然后输入内容，整个页面的滚动会错误地把输入框也滚没了，很恼人。改为只滚动 `chat-body` 这部分 DOM 的滚动条。
- 移动端输入框，高度改小，发送按钮的文字去掉。降低输入框面积的占比，
- 移动端输入框，在发送后自动失焦，把键盘收起来，尽可能多地呈现GPT的回复。（因为在这个ChatGPT场景下，用户不会连续发送消息，都是发一句等着回复）

以上遵循的体验原则主要是：
- 移动端应该尽量简洁，交互路径短一点，能点一下的不点两下。
- 不像pc端用户可以多线程操作，移动端屏幕小，尽量让用户单线程操作：打字的时候输入框和输入法占大头，看消息的时候输入法就应该自动收起，以回复消息显示最大化。

望采纳～