### PR TITLE
ci(sync): add push permission

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,8 @@
 name: Upstream Sync
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: "0 */6 * * *" # every 6 hours
@@ -12,7 +15,7 @@ jobs:
     if: ${{ github.event.repository.fork }}
 
     steps:
-      # Step 1: run a standard checkout action, provided by github
+      # Step 1: run a standard checkout action
       - name: Checkout target repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
在配置中增加操作权限，避免下游因未在设置中开启`GITHUB_TOKEN`的write权限产生的[403报错](https://github.com/yorunning/ChatGPT-Next-Web/actions/runs/4593191664/jobs/8110891207#step:3:143)
https://github.com/Yidadaa/ChatGPT-Next-Web/issues/316#issuecomment-1492988311
这样下游不用单独进行设置了
