### PR TITLE
optimize: scrolling experience

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -627,9 +627,6 @@ export function Chat(props: {
               setAutoScroll(false);
               setTimeout(() => setPromptHints([]), 500);
             }}
-            onMouseOver={() => {
-              inputRef.current?.focus();
-            }}
             autoFocus={!props?.sideBarShowing}
           />
           <IconButton

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -593,7 +593,6 @@ export function Chat(props: {
                         if (!isMobileScreen()) return;
                         setUserInput(message.content);
                       }}
-                      onMouseOver={() => inputRef.current?.blur()}
                     >
                       <Markdown content={message.content} />
                     </div>

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -377,7 +377,8 @@ export function Chat(props: {
     chatStore.onUserInput(userInput).then(() => setIsLoading(false));
     setUserInput("");
     setPromptHints([]);
-    inputRef.current?.focus();
+    if (!isMobileScreen()) inputRef.current?.focus();
+    setAutoScroll(true);
   };
 
   // stop response
@@ -533,8 +534,11 @@ export function Chat(props: {
         className={styles["chat-body"]}
         ref={scrollRef}
         onScroll={(e) => onChatBodyScroll(e.currentTarget)}
-        onMouseOver={() => inputRef.current?.blur()}
-        onTouchStart={() => inputRef.current?.blur()}
+        onWheel={() => setAutoScroll(false)}
+        onTouchStart={() => {
+          inputRef.current?.blur();
+          setAutoScroll(false);
+        }}
       >
         {messages.map((message, i) => {
           const isUser = message.role === "user";


### PR DESCRIPTION
- 桌面端 `onWheel` 的时候再取消自动滚动更好，不然鼠标一移上去就失去焦点无法输入了。
- 移动端发送消息之后最好是收起键盘，以最大的显示空间等待GPT回复。
- 不使用`focus()` 和 `blur()` 来间接控制 `setAutoScroll` ，因为二次聚焦/失焦的时候不会触发 `onFocus`和`onBlur`。