### PR TITLE
Support custom emoji url

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -33,6 +33,8 @@ import chatStyle from "./chat.module.scss";
 
 import { Modal, showModal, showToast } from "./ui-lib";
 
+import { getEmojiUrl } from "@/config";
+
 const Markdown = dynamic(async () => (await import("./markdown")).Markdown, {
   loading: () => <LoadingIcon />,
 });
@@ -50,7 +52,13 @@ export function Avatar(props: { role: Message["role"] }) {
 
   return (
     <div className={styles["user-avtar"]}>
-      <Emoji unified={config.avatar} size={18} />
+      <Emoji
+        unified={config.avatar}
+        size={18}
+        getEmojiUrl={(unified = config.avatar) =>
+          `${getEmojiUrl}${unified}.png`
+        }
+      />
     </div>
   );
 }

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -33,6 +33,8 @@ import { SearchService, usePromptStore } from "../store/prompt";
 import { requestUsage } from "../requests";
 import { ErrorBoundary } from "./error";
 
+import { getEmojiUrl } from "@/config";
+
 function SettingItem(props: {
   title: string;
   subTitle?: string;
@@ -180,6 +182,9 @@ export function Settings(props: { closeSettings: () => void }) {
               onClose={() => setShowEmojiPicker(false)}
               content={
                 <EmojiPicker
+                  getEmojiUrl={(unified = config.avatar) =>
+                    `${getEmojiUrl}${unified}.png`
+                  }
                   lazyLoadEmojis
                   theme={EmojiTheme.AUTO}
                   onEmojiClick={(e) => {

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,3 @@
+// export const getEmojiUrl = 反代的地址 ?? "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/"
+// https://github.com/ealush/emoji-picker-react/blob/master/src/config/cdnUrls.ts
+export const getEmojiUrl = null ?? "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/"


### PR DESCRIPTION
https://github.com/Yidadaa/ChatGPT-Next-Web/issues/466
可能方式不是特别优雅，但可以解决该问题。

把null换成反代的地址

假设我反代`cdn.jsdelivr.net`的地址为`yourreverseproxydomain.com`，就把配置改为

```ts
export const getEmojiUrl = "https://yourreverseproxydomain.com/npm/emoji-datasource-apple/img/apple/64/" ?? "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/"
```