### PR TITLE
fix: bug of deleting chat on pc and remove delete button on mobile

### DIFF
--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -35,9 +35,11 @@ export function ChatItem(props: {
         </div>
         <div className={styles["chat-item-date"]}>{props.time}</div>
       </div>
-      <div className={styles["chat-item-delete"]} onClick={props.onDelete}>
-        <DeleteIcon />
-      </div>
+      {!isMobileScreen() ? (
+        <div className={styles["chat-item-delete"]} onClick={props.onDelete}>
+          <DeleteIcon />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -63,7 +65,8 @@ export function ChatList() {
           selected={i === selectedIndex}
           onClick={() => selectSession(i)}
           onDelete={() =>
-            (!isMobileScreen() || confirm(Locale.Home.DeleteChat)) &&
+            !isMobileScreen() &&
+            confirm(Locale.Home.DeleteChat) &&
             removeSession(i)
           }
         />


### PR DESCRIPTION
1. 修复pc端中删除时确定提示
2. 由于在移动端中设置旁边已有删除对话按钮，所以在对话列表右上角无需再显示删除按钮，显得功能重复。


![1680624162383](https://user-images.githubusercontent.com/30711792/229851049-21545dcf-754d-4632-a18f-86987a9e0e48.jpg)
