### PR TITLE
chore: removed redundant checkUsage

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -113,7 +113,6 @@ export function Settings(props: { closeSettings: () => void }) {
 
   useEffect(() => {
     checkUpdate();
-    checkUsage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
`checkUsage()` was already called by another `useEffect`. There is no need to call it twice.