### PR TITLE
fix: header title overflow

### DIFF
--- a/app/components/window.scss
+++ b/app/components/window.scss
@@ -10,6 +10,7 @@
 
 .window-header-title {
   max-width: calc(100% - 100px);
+  overflow: hidden;
 
   .window-header-main-title {
     font-size: 20px;


### PR DESCRIPTION
before:
![1](https://user-images.githubusercontent.com/25226871/230069217-275394e7-fdea-4979-8485-86ca2cc911a7.png)

after:
![2](https://user-images.githubusercontent.com/25226871/230069199-ec85d436-8c06-431c-959e-251c464c72f4.png)
