### PR TITLE
feat: 修复因为截断导致的宽字符乱码问题

### DIFF
--- a/app/requests.ts
+++ b/app/requests.ts
@@ -159,7 +159,10 @@ export async function requestChatStream(
 
     if (res.ok) {
       const reader = res.body?.getReader();
-      const decoder = new TextDecoder();
+      const decoder = new TextDecoder("utf-8", {
+        fatal: true,
+        ignoreBOM: true,
+      });
 
       options?.onController?.(controller);
 
@@ -168,13 +171,12 @@ export async function requestChatStream(
         const resTimeoutId = setTimeout(() => finish(), TIME_OUT_MS);
         const content = await reader?.read();
         clearTimeout(resTimeoutId);
-        const text = decoder.decode(content?.value);
+        const text = decoder.decode(content?.value, { stream: !content?.done });
         responseText += text;
 
-        const done = !content || content.done;
         options?.onMessage(responseText, false);
 
-        if (done) {
+        if (content?.done) {
           break;
         }
       }


### PR DESCRIPTION
主要优化点：
1. 在 TextDecoder 中指定了编码及是否要严格检查编码，使用 `{ fatal: true }` 可以让 TextDecoder 抛出异常避免截断 utf8 字符;
2. 在 TextDecoder 中指定是否忽略 UTF-8 BOM，使用 `{ ignoreBOM: true }` 避免 BOM 被解析成乱码;
3. 在 TextDecoder 中使用 stream 模式避免截断 UTF8 字符。