### PR TITLE
fix: re-render if isMobileScreen() changes

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -20,6 +20,7 @@ import {
   ROLES,
   createMessage,
 } from "../store";
+import { useScreen } from "../store/screen";
 
 import {
   copyToClipboard,
@@ -348,6 +349,8 @@ export function Chat(props: {
   const { scrollRef, setAutoScroll } = useScrollToBottom();
   const [hitBottom, setHitBottom] = useState(false);
 
+  const isMobile = useScreen(screen => screen.isMobile);
+
   const onChatBodyScroll = (e: HTMLElement) => {
     const isTouchBottom = e.scrollTop + e.clientHeight >= e.scrollHeight - 20;
     setHitBottom(isTouchBottom);
@@ -409,7 +412,7 @@ export function Chat(props: {
     chatStore.onUserInput(userInput).then(() => setIsLoading(false));
     setUserInput("");
     setPromptHints([]);
-    if (!isMobileScreen()) inputRef.current?.focus();
+    if (!isMobile) inputRef.current?.focus();
     setAutoScroll(true);
   };
 
@@ -499,7 +502,7 @@ export function Chat(props: {
 
   // Auto focus
   useEffect(() => {
-    if (props.sideBarShowing && isMobileScreen()) return;
+    if (props.sideBarShowing && isMobile) return;
     inputRef.current?.focus();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -635,7 +638,7 @@ export function Chat(props: {
                       style={{ fontSize: `${fontSize}px` }}
                       onContextMenu={(e) => onRightClick(e, message)}
                       onDoubleClickCapture={() => {
-                        if (!isMobileScreen()) return;
+                        if (!isMobile) return;
                         setUserInput(message.content);
                       }}
                     >

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -17,7 +17,8 @@ import LoadingIcon from "../icons/three-dots.svg";
 import CloseIcon from "../icons/close.svg";
 
 import { useChatStore } from "../store";
-import { isMobileScreen } from "../utils";
+import { useScreen } from "../store/screen";
+
 import Locale from "../locales";
 import { Chat } from "./chat";
 
@@ -99,6 +100,7 @@ function _Home() {
   // setting
   const [openSettings, setOpenSettings] = useState(false);
   const config = useChatStore((state) => state.config);
+  const isMobile = useScreen(screen => screen.isMobile);
 
   useSwitchTheme();
 
@@ -109,7 +111,7 @@ function _Home() {
   return (
     <div
       className={`${
-        config.tightBorder && !isMobileScreen()
+        config.tightBorder && !isMobile
           ? styles["tight-container"]
           : styles.container
       }`}

--- a/app/store/screen.ts
+++ b/app/store/screen.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { isMobileScreen } from "../utils";
+
+interface Screen {
+  isMobile: boolean;
+  update: () => void;
+}
+
+export const useScreen = create<Screen>(set => {
+  const state = {
+    isMobile: isMobileScreen(),
+    update: () => set({ isMobile: isMobileScreen() }),
+  };
+  if (typeof window !== "undefined") {
+    window.addEventListener("resize", e => {
+      state.update();
+    });
+  }
+  return state;
+});

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -49,6 +49,9 @@ export function isIOS() {
 }
 
 export function isMobileScreen() {
+  if (typeof window === "undefined") {
+    return false;
+  }
   return window.innerWidth <= 600;
 }
 


### PR DESCRIPTION
`isMobileScreen` 发生变化应该触发重画。否则在紧凑边框开启时会有问题：
- 设置界面开启，缩小窗口成移动大小，不显示工具栏关闭设置界面
- 从移动大小扩大窗口，“紧凑边框”设置无效，仍使用非紧凑边框

下面是对于第一个问题的前后对比：
[Screen recording 2023-04-05 23.52.16.webm](https://user-images.githubusercontent.com/445459/230295379-ae8f2014-da06-4b07-9c92-4ba7468c511a.webm)
