### PR TITLE
fix: distinguish PC/Mobile behavior on auto-scroll

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -421,6 +421,7 @@ export function Chat(props: {
   // check if should send message
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (shouldSubmit(e)) {
+      setAutoScroll(true);
       onUserSubmit();
       e.preventDefault();
     }
@@ -667,7 +668,7 @@ export function Chat(props: {
             onInput={(e) => onInput(e.currentTarget.value)}
             value={userInput}
             onKeyDown={onInputKeyDown}
-            onFocus={() => setAutoScroll(true)}
+            onFocus={() => setAutoScroll(isMobileScreen())}
             onBlur={() => {
               setAutoScroll(false);
               setTimeout(() => setPromptHints([]), 500);


### PR DESCRIPTION
当移动端用户点击输入文本框后，聊天列表应该自动滚动（与当前一致）。

但在电脑屏幕上，聊天列表不应该自动滚动，因为用户可能需要参考之前的聊天记录。

本提交将电脑屏幕中自动滚动逻辑移动到 submit 时刻。