### PR TITLE
[refactor] rename ChatResponse.

### DIFF
--- a/app/api/openai/typing.ts
+++ b/app/api/openai/typing.ts
@@ -4,4 +4,4 @@ import type {
 } from "openai";
 
 export type ChatRequest = CreateChatCompletionRequest;
-export type ChatReponse = CreateChatCompletionResponse;
+export type ChatResponse = CreateChatCompletionResponse;

--- a/app/requests.ts
+++ b/app/requests.ts
@@ -1,4 +1,4 @@
-import type { ChatRequest, ChatReponse } from "./api/openai/typing";
+import type { ChatRequest, ChatResponse } from "./api/openai/typing";
 import { Message, ModelConfig, useAccessStore, useChatStore } from "./store";
 import { showToast } from "./components/ui-lib";
 
@@ -67,7 +67,7 @@ export async function requestChat(messages: Message[]) {
   const res = await requestOpenaiClient("v1/chat/completions")(req);
 
   try {
-    const response = (await res.json()) as ChatReponse;
+    const response = (await res.json()) as ChatResponse;
     return response;
   } catch (error) {
     console.error("[Request Chat] ", error, res.body);


### PR DESCRIPTION
Fix the incorrect spelling for `response`

修复错误的拼写