### PR TITLE
fix:修复正常响应结果后额外追加‘出错了,请稍后再试’bug

### DIFF
--- a/app/requests.ts
+++ b/app/requests.ts
@@ -171,10 +171,15 @@ export async function requestChatStream(
         const resTimeoutId = setTimeout(() => finish(), TIME_OUT_MS);
         const content = await reader?.read();
         clearTimeout(resTimeoutId);
-        const text = decoder.decode(content?.value, { stream: true });
+      
+        if (!content || !content.value) {
+          break;
+        }
+      
+        const text = decoder.decode(content.value, { stream: true });
         responseText += text;
 
-        const done = !content || content.done;
+        const done = content.done;
         options?.onMessage(responseText, false);
 
         if (done) {


### PR DESCRIPTION
使用Vercel 免费一键部署 后的项目可以正常访问，也可以正常回复 但是每条回复一句后面都会莫名奇妙追加一句话‘出错了,请稍后再试’，本次修改旨在解决此bug