### PR TITLE
fix docker proxy config

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -137,7 +137,8 @@ docker run -d -p 3000:3000 \
 docker run -d -p 3000:3000 \
    -e OPENAI_API_KEY="sk-xxxx" \
    -e CODE="页面访问密码" \
-   -e PROXY_URL="http://localhost:7890" \
+   --net=host \
+   -e PROXY_URL="http://127.0.0.1:7890" \
    yidadaa/chatgpt-next-web
 ```
 


### PR DESCRIPTION
Docker 配置代理部分存在错误。容器启动后 proxychains 报错，提示不接受非数字形式的代理地址，因此将代理地址更改为 127.0.0.1，同时修改容器的网络模式为 host