### PR TITLE
The require introduction is replaced by import, and the npm source is replaced with the new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ public/prompts.json
 
 .vscode
 .idea
+
+pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn config set registry 'https://registry.npm.taobao.org'
+RUN yarn config set registry 'https://registry.npmmirror.com'
 RUN yarn install
 
 FROM base AS builder

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-require("../polyfill");
+import "../polyfill.ts";
 
 import { useState, useEffect, useRef } from "react";
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "emoji-picker-react": "^4.4.7",
     "eventsource-parser": "^0.1.0",
     "fuse.js": "^6.6.2",
-    "next": "^13.3.1-canary.8",
+    "next": "^13.3.0",
     "node-fetch": "^3.3.1",
     "openai": "^3.2.1",
     "react": "^18.2.0",


### PR DESCRIPTION
1.https://registry.npm.taobao.org with https://registry.npmmirror.com
2.require(".. /polyfill") with import introduction
3.Maybe we need to use a stable version such as next