### PR TITLE
Improve the logic for scrolling to the bottom

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -434,7 +434,7 @@ export function Chat(props: {
   const [hitBottom, setHitBottom] = useState(false);
 
   const onChatBodyScroll = (e: HTMLElement) => {
-    const isTouchBottom = e.scrollTop + e.clientHeight >= e.scrollHeight - 20;
+    const isTouchBottom = e.scrollTop + e.clientHeight >= e.scrollHeight;
     setHitBottom(isTouchBottom);
   };
 


### PR DESCRIPTION
Remove unnecessary 20px offset, because `scrollHeight = clientHeight + scrollTop` 
Fix: #905