### PR TITLE
修复 Edge Runtime 设置失效问题

### DIFF
--- a/app/api/chat-stream/route.ts
+++ b/app/api/chat-stream/route.ts
@@ -59,6 +59,4 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "experimental-edge";

--- a/app/api/openai/route.ts
+++ b/app/api/openai/route.ts
@@ -30,6 +30,4 @@ export async function GET(req: NextRequest) {
   return makeRequest(req);
 }
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "experimental-edge";


### PR DESCRIPTION
在 Next.js 13.3.1 中， export config 被弃用，See https://beta.nextjs.org/docs/api-reference/segment-config.