### PR TITLE
Route Segment Config 遗漏

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -19,3 +19,5 @@ export async function POST(req: NextRequest) {
     needCode: serverConfig.needCode,
   });
 }
+
+export const runtime = "experimental-edge";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,3 +14,5 @@ export default async function App() {
     </>
   );
 }
+
+export const runtime = "experimental-edge";


### PR DESCRIPTION
尝试 cloudflare page 部署时, 根据 [build-output-api](https://vercel.com/docs/build-output-api/v3/configuration), 发现 [#239](https://github.com/Yidadaa/ChatGPT-Next-Web/issues/239#issuecomment-1493414462) 问题是缺少 runtime config。

`vercel build`, 检查 `./.vercel/output/functions/**/.vc-config.json`,  部分是 ` "runtime": "nodejs18.x"`

根据 [segment-config](https://beta.nextjs.org/docs/api-reference/segment-config)
> The Route Segment Config Options allows you configure the behavior of a Page, Layout or Route Handler

添加 runtime 后可以正常在 cloudflare pages 部署, 但目前访问存在问题; 

log 里会提示 `"message": "Dynamic require of \"node:buffer\" is not supported"` , 应该是这个 next-on-pages 上这个 [PR](https://github.com/cloudflare/next-on-pages/pull/186)  没有完全解决问题