### PR TITLE
proxy host can be use domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ EXPOSE 3000
 CMD if [ -n "$PROXY_URL" ]; then \
         protocol=$(echo $PROXY_URL | cut -d: -f1); \
         host=$(echo $PROXY_URL | cut -d/ -f3 | cut -d: -f1); \
+        host=$(nslookup $host | grep -A1 'Name:' | tail -1 | awk '{print $2}') \
         port=$(echo $PROXY_URL | cut -d: -f3); \
         conf=/etc/proxychains.conf; \
         echo "strict_chain" > $conf; \


### PR DESCRIPTION
like this : PROXY_URL="socks5://host.docker.internal:7890" 

 fix "proxy host.docker.internal has invalid value or is not numeric"