### PR TITLE
fix: use innerHTML may leads unexpected script execution

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -129,7 +129,7 @@ export function autoGrowTextArea(dom: HTMLTextAreaElement) {
 
   const width = getDomContentWidth(dom);
   measureDom.style.width = width + "px";
-  measureDom.innerHTML = dom.value.trim().length > 0 ? dom.value : "1";
+  measureDom.innerText = dom.value.trim().length > 0 ? dom.value : "1";
 
   const lineWrapCount = Math.max(0, dom.value.split("\n").length - 1);
   const height = parseFloat(window.getComputedStyle(measureDom).height);


### PR DESCRIPTION
When typing `<meta http-equiv="refresh" content="0;http://google.com">` in the input area, the page redirects to google.com.
Changing innerHTML to innerText will fix it.