### PR TITLE
feat: Add option to open links in same window for internal links

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -98,12 +98,8 @@ export function Markdown(
           }}
             renderers={{
               link: (props) => {
-                // 判断链接是否为内部地址
                 const isInternal = /^\/(?!\/)/.test(props.href);
-
-                // 如果是内部地址，使用_self，否则使用_blank
                 const target = isInternal ? "_self" : "_blank";
-
                 return <a {...props} target={target} />;
               },
             }}

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -96,7 +96,8 @@ export function Markdown(
           components={{
             pre: PreCode,
           a: (aProps) => {
-            const isInternal = /^\/#/i.test(aProps.href);
+            const href = aProps.href || "";
+            const isInternal = /^\/#/i.test(href); 
             const target = isInternal ? "_self" : aProps.target ?? "_blank";
             return <a {...aProps} target={target} />;
           },

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -95,13 +95,11 @@ export function Markdown(
           ]}
           components={{
             pre: PreCode,
-          }}
-            renderers={{
-              link: (props) => {
-                const isInternal = /^\/(?!\/)/.test(props.href);
-                const target = isInternal ? "_self" : "_blank";
-                return <a {...props} target={target} />;
-              },
+          a: (aProps) => {
+            const isInternal = /^\/#/i.test(aProps.href);
+            const target = isInternal ? "_self" : aProps.target ?? "_blank";
+            return <a {...aProps} target={target} />;
+          },
             }}
         >
           {props.content}

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -96,7 +96,17 @@ export function Markdown(
           components={{
             pre: PreCode,
           }}
-          linkTarget={"_blank"}
+            renderers={{
+              link: (props) => {
+                // 判断链接是否为内部地址
+                const isInternal = /^\/(?!\/)/.test(props.href);
+
+                // 如果是内部地址，使用_self，否则使用_blank
+                const target = isInternal ? "_self" : "_blank";
+
+                return <a {...props} target={target} />;
+              },
+            }}
         >
           {props.content}
         </ReactMarkdown>


### PR DESCRIPTION
This PR adds a new feature that allows internal links in the Markdown component to open in the same window instead of opening in a new page. 