### PR TITLE
完善会话默认选中的逻辑

### DIFF
--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -16,6 +16,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { Path } from "../constant";
 import { MaskAvatar } from "./mask";
 import { Mask } from "../store/mask";
+import { MouseEvent } from "react";
 
 export function ChatItem(props: {
   onClick?: () => void;
@@ -29,6 +30,14 @@ export function ChatItem(props: {
   narrow?: boolean;
   mask: Mask;
 }) {
+  const handleDeleteClick = (event: MouseEvent) => {
+    // Avoid triggering the onClick event of the parent component.
+    event.stopPropagation();
+    if (props.onDelete) {
+      props.onDelete();
+    }
+  };
+
   return (
     <Draggable draggableId={`${props.id}`} index={props.index}>
       {(provided) => (
@@ -67,7 +76,10 @@ export function ChatItem(props: {
             </>
           )}
 
-          <div className={styles["chat-item-delete"]} onClick={props.onDelete}>
+          <div
+            className={styles["chat-item-delete"]}
+            onClick={handleDeleteClick}
+          >
             <DeleteIcon />
           </div>
         </div>

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -81,8 +81,13 @@ function useDragSideBar() {
 }
 
 export function SideBar(props: { className?: string }) {
-  const chatStore = useChatStore();
-
+  const [newSession, deleteSession, currentSessionIndex] = useChatStore(
+    (state) => [
+      state.newSession,
+      state.deleteSession,
+      state.currentSessionIndex,
+    ],
+  );
   // drag side bar
   const { onDragMouseDown, shouldNarrow } = useDragSideBar();
   const navigate = useNavigate();
@@ -138,7 +143,9 @@ export function SideBar(props: { className?: string }) {
           <div className={styles["sidebar-action"] + " " + styles.mobile}>
             <IconButton
               icon={<CloseIcon />}
-              onClick={chatStore.deleteSession}
+              onClick={() => {
+                deleteSession(currentSessionIndex);
+              }}
             />
           </div>
           <div className={styles["sidebar-action"]}>
@@ -158,7 +165,7 @@ export function SideBar(props: { className?: string }) {
             text={shouldNarrow ? undefined : Locale.Home.NewChat}
             onClick={() => {
               if (config.dontShowMaskSplashScreen) {
-                chatStore.newSession();
+                newSession();
               } else {
                 navigate(Path.NewChat);
               }


### PR DESCRIPTION
fix: #1130

删除会话后，默认选中的逻辑：
如果删除的会话是当前选中的会话，将下一个会话作为默认选中。
如果删除的会话不是当前选中的会话，保持当前会话的选中状态。

撤销删除后，默认选中的逻辑：
如果删除的会话删除前是选中状态，恢复会话的同时恢复选中的状态。
如果删除的会话删除前不是选中的状态，则恢复会话后，保持当前选中的会话窗口的选中状态不变。