### PR TITLE
Fix: navigate cause re-render

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -16,7 +16,7 @@ import { Path, SlotID } from "../constant";
 import { ErrorBoundary } from "./error";
 
 import {
-  HashRouter as Router,
+  MemoryRouter as Router,
   Routes,
   Route,
   useLocation,


### PR DESCRIPTION
Sometimes navigate(-1) cause the page re-rendering and broken, like this:
![图片](https://user-images.githubusercontent.com/7258605/235119219-369dd44e-9fed-4f67-87a1-4b64ad4ec2a2.png)
Using memory route to fix it.