### PR TITLE
fix: 'end_date must come after start_date' error

### DIFF
--- a/app/requests.ts
+++ b/app/requests.ts
@@ -102,7 +102,7 @@ export async function requestUsage() {
       .getDate()
       .toString()
       .padStart(2, "0")}`;
-  const ONE_DAY = 2 * 24 * 60 * 60 * 1000;
+  const ONE_DAY = 1 * 24 * 60 * 60 * 1000;
   const now = new Date(Date.now() + ONE_DAY);
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
   const startDate = formatDate(startOfMonth);


### PR DESCRIPTION
fix: Pressing the Usage Check Button prompts an error message "end_date must come after start_date"