### PR TITLE
fix:  #1201 prompts cannot selected correctly

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -232,7 +232,10 @@ export function PromptHints(props: {
         <div
           className={styles["prompt-hint"]}
           key={prompt.title + i.toString()}
-          onClick={() => props.onPromptSelect(prompt)}
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onPromptSelect(prompt);
+          }}
         >
           <div className={styles["hint-title"]}>{prompt.title}</div>
           <div className={styles["hint-content"]}>{prompt.content}</div>
@@ -386,9 +389,9 @@ export function Chat() {
   );
 
   const onPromptSelect = (prompt: Prompt) => {
+    setUserInput(prompt.content);
     setPromptHints([]);
     inputRef.current?.focus();
-    setTimeout(() => setUserInput(prompt.content), 60);
   };
 
   // auto grow input
@@ -574,7 +577,16 @@ export function Chat() {
   }, []);
 
   return (
-    <div className={styles.chat} key={session.id}>
+    <div
+      className={styles.chat}
+      key={session.id}
+      onClick={(e) => {
+        if (e.target !== inputRef.current) {
+          setAutoScroll(false);
+          setPromptHints([]);
+        }
+      }}
+    >
       <div className="window-header">
         <div className="window-header-title">
           <div
@@ -762,14 +774,6 @@ export function Chat() {
             value={userInput}
             onKeyDown={onInputKeyDown}
             onFocus={() => setAutoScroll(true)}
-            onBlur={() => {
-              setTimeout(() => {
-                if (document.activeElement !== inputRef.current) {
-                  setAutoScroll(false);
-                  setPromptHints([]);
-                }
-              }, 100);
-            }}
             autoFocus
             rows={inputRows}
           />


### PR DESCRIPTION
Please read my comments in https://github.com/Yidadaa/ChatGPT-Next-Web/issues/1201 before starting to do code review on my pull request,  Thanks.

In my implementation, I used the solution that how a modal is closed if a user clicks outside of the modal.
so any click event inside <Chat/> component, except the selected prompt element, which stops the bubble up propagation.
 (
```
 onClick={(e) => {
            e.stopPropagation();
            props.onPromptSelect(prompt);
          }}
  ```
)
can result in the prompt list gracefully closed.

also with this implementation, it make's this enhancement https://github.com/Yidadaa/ChatGPT-Next-Web/issues/782 much easier.

please ignore the closed pull request #1215