### PR TITLE
resolve problem about basic auth when the app is behind a proxy server

### DIFF
--- a/app/requests.ts
+++ b/app/requests.ts
@@ -44,9 +44,7 @@ const makeRequestParam = (
 
 function getHeaders() {
   const accessStore = useAccessStore.getState();
-  const headers = {
-    Authorization: "",
-  };
+  let headers: Record<string, string> = {};
 
   const makeBearer = (token: string) => `Bearer ${token.trim()}`;
   const validString = (x: string) => x && x.length > 0;


### PR DESCRIPTION
When we use the app behind a nginx reverse proxy with basic authorization. The `getHeader` function will reset the "Authorization" field and lead to a 401 error.

This patch resolve the problem.