### PR TITLE
fix: bug #1240

### DIFF
--- a/scripts/fetch-prompts.mjs
+++ b/scripts/fetch-prompts.mjs
@@ -40,7 +40,7 @@ async function fetchEN() {
     return raw
       .split("\n")
       .slice(1)
-      .map((v) => v.split('","').map((v) => v.replace('"', "")));
+      .map((v) => v.split('","').map((v) => v.replace(/^"|"$/g, '').replaceAll('""','"')));
   } catch (error) {
     console.error("[Fetch] failed to fetch en prompts", error);
     return [];


### PR DESCRIPTION
the original logic
Let's take a shortened example of prompt from the remote cvs file.
which can be below:
`
"javascript console","it prints console.log(""hello world"")"
`
```
v.split('","').map((v) => v.replace('"', "")))
```
after `split` method, it becomes an array:
` [ '"javascript console', 'it prints console.log(""hello world"")"'] `
if calling ` v.replace('"', "")`, which only replace the first `"`,  the prompt becomes:
` [ '"javascript console', 'it prints console.log("hello world"")"' ] `

this is what I described in the bug report:
https://github.com/Yidadaa/ChatGPT-Next-Web/issues/1240 
```
v.replace(/^"|"$/g, '').replaceAll('""','"')))
```
my fix is, first replace the single `"`  with '', in the head or the tail of the split elements, then replace  all `""` with `"`
