### PR TITLE
fix: show Loading Icon when checking repo update

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -7,6 +7,7 @@ import AddIcon from "../icons/add.svg";
 import CloseIcon from "../icons/close.svg";
 import CopyIcon from "../icons/copy.svg";
 import ClearIcon from "../icons/clear.svg";
+import LoadingIcon from "../icons/three-dots.svg";
 import EditIcon from "../icons/edit.svg";
 import EyeIcon from "../icons/eye.svg";
 import { Input, List, ListItem, Modal, PasswordInput, Popover } from "./ui-lib";
@@ -352,7 +353,7 @@ export function Settings() {
             }
           >
             {checkingUpdate ? (
-              <div />
+              <LoadingIcon />
             ) : hasNewVersion ? (
               <Link href={UPDATE_URL} target="_blank" className="link">
                 {Locale.Settings.Update.GoToUpdate}


### PR DESCRIPTION
in `Settings` page, when checking update is on the way, it's better to show an animating icon, here i use `<LoadingIcon />`, rather than an empty `<div/>`.