### PR TITLE
feat: mobile chat overscroll-behavior none

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -335,6 +335,7 @@
   padding: 20px;
   padding-bottom: 40px;
   position: relative;
+  overscroll-behavior: none;
 }
 
 .chat-body-title {


### PR DESCRIPTION
在移动端聊天窗口滚动到边界后会触发浏览器的刷新行为，故使用overscroll-behavior: none;将其禁止

参考：https://developer.mozilla.org/zh-CN/docs/Web/CSS/overscroll-behavior