### PR TITLE
fix: styles on .user-prompt-buttons

### DIFF
--- a/app/components/settings.module.scss
+++ b/app/components/settings.module.scss
@@ -69,7 +69,4 @@
       }
     }
   }
-
-  .user-prompt-actions {
-  }
 }

--- a/app/components/settings.module.scss
+++ b/app/components/settings.module.scss
@@ -60,13 +60,11 @@
       .user-prompt-buttons {
         display: flex;
         align-items: center;
+        column-gap: 2px;
 
         .user-prompt-button {
-          height: 100%;
-
-          &:not(:last-child) {
-            margin-right: 5px;
-          }
+          //height: 100%;
+          padding: 7px;
         }
       }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2328124/236710544-03df4cc5-46e6-4b47-a9de-6ee2a40a90b3.png)

As in this snapshot, if you create empty prompts without editing the conent, nothing is wrong see **A**, but as long as you have long contents, well, the button groups starts displaying incorrectly, see **B**.

The reason is, 
```css
.user-prompt-header {
        max-width: calc(100% - 100px);
}
```
it only leaves `100px` for the 3 buttons with full prompt contents.  I don't think to reduce the max width of the content is a good idea, because we also need to display the content in mobile devices.

so the only way i can do is to slim the buttons,  originally, each button has a padding of `10px`, which takes up `20 px` space, so i reduced it to `padding: 7px;`, not only that, i see the gap between two buttons from `5px` to `2px`.
by the way, I recommend using  css properties of `column-gap` or `row-gap` in both `flex` and `grid` layouts , which is sightly better than 
```css
&:not(:last-child) {
            margin-right: 5px;
          }
```

also I commented out `height: 100%;`, if you need, you may change it back. 
