### PR TITLE
feat: sync code every day instead of every hour

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 * * * *" # every hour
+    - cron: "0 0 * * *" # every day
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
因为 Vercel 频繁更新会失败，遂建议改为一天同步一次。

相似pr #1262 