### PR TITLE
Feature/switch chat with hot key

### DIFF
--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -123,18 +123,12 @@ export function ChatList(props: { narrow?: boolean }) {
         return;
       }
 
-      if (ctrlArrowUp) {
-        console.log("向上", selectedIndex);
-        if (selectedIndex !== 0) {
-          selectSession(selectedIndex - 1);
-        }
+      if (ctrlArrowUp && selectedIndex !== 0) {
+        selectSession(selectedIndex - 1);
       }
 
-      if (ctrlArrowDown) {
-        console.log("向下", selectedIndex);
-        if (selectedIndex !== sessions.length - 1) {
-          selectSession(selectedIndex + 1);
-        }
+      if (ctrlArrowDown && selectedIndex !== sessions.length - 1) {
+        selectSession(selectedIndex + 1);
       }
     };
     window.addEventListener("keydown", onKeyDown);

--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -16,7 +16,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { Path, SlotID } from "../constant";
 import { MaskAvatar } from "./mask";
 import { Mask } from "../store/mask";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export function ChatItem(props: {
   onClick?: () => void;
@@ -91,6 +91,7 @@ export function ChatList(props: { narrow?: boolean }) {
   );
   const chatStore = useChatStore();
   const navigate = useNavigate();
+  const selectedRef = useRef<HTMLDivElement>(null);
 
   const onDragEnd: OnDragEndResponder = (result) => {
     const { destination, source } = result;
@@ -130,6 +131,10 @@ export function ChatList(props: { narrow?: boolean }) {
       if (ctrlArrowDown && selectedIndex !== sessions.length - 1) {
         selectSession(selectedIndex + 1);
       }
+
+      selectedRef.current?.scrollIntoView({
+        block: "center",
+      });
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -146,27 +151,29 @@ export function ChatList(props: { narrow?: boolean }) {
             {...provided.droppableProps}
           >
             {sessions.map((item, i) => (
-              <ChatItem
-                title={item.topic}
-                time={new Date(item.lastUpdate).toLocaleString()}
-                count={item.messages.length}
-                key={item.id}
-                id={item.id}
-                index={i}
-                selected={i === selectedIndex}
-                onClick={() => {
-                  navigate(Path.Chat);
-                  selectSession(i);
-                }}
-                onDelete={() => {
-                  if (!props.narrow || confirm(Locale.Home.DeleteChat)) {
-                    chatStore.deleteSession(i);
-                  }
-                }}
-                narrow={props.narrow}
-                mask={item.mask}
-              />
+              <div key={item.id} ref={i === selectedIndex ? selectedRef : null}>
+                <ChatItem
+                  title={item.topic}
+                  time={new Date(item.lastUpdate).toLocaleString()}
+                  count={item.messages.length}
+                  id={item.id}
+                  index={i}
+                  selected={i === selectedIndex}
+                  onClick={() => {
+                    navigate(Path.Chat);
+                    selectSession(i);
+                  }}
+                  onDelete={() => {
+                    if (!props.narrow || confirm(Locale.Home.DeleteChat)) {
+                      chatStore.deleteSession(i);
+                    }
+                  }}
+                  narrow={props.narrow}
+                  mask={item.mask}
+                />
+              </div>
             ))}
+
             {provided.placeholder}
           </div>
         )}

--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -13,9 +13,10 @@ import { useChatStore } from "../store";
 
 import Locale from "../locales";
 import { Link, useNavigate } from "react-router-dom";
-import { Path } from "../constant";
+import { Path, SlotID } from "../constant";
 import { MaskAvatar } from "./mask";
 import { Mask } from "../store/mask";
+import { useEffect } from "react";
 
 export function ChatItem(props: {
   onClick?: () => void;
@@ -106,6 +107,40 @@ export function ChatList(props: { narrow?: boolean }) {
 
     moveSession(source.index, destination.index);
   };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      e.stopPropagation();
+      const ctrlArrowUp = (e.metaKey || e.ctrlKey) && e.key === "ArrowUp";
+      const ctrlArrowDown = (e.metaKey || e.ctrlKey) && e.key === "ArrowDown";
+      const activeElement = document.activeElement;
+
+      if (
+        activeElement instanceof HTMLTextAreaElement &&
+        activeElement.id === SlotID.chatInput &&
+        activeElement?.value !== ""
+      ) {
+        return;
+      }
+
+      if (ctrlArrowUp) {
+        console.log("向上", selectedIndex);
+        if (selectedIndex !== 0) {
+          selectSession(selectedIndex - 1);
+        }
+      }
+
+      if (ctrlArrowDown) {
+        console.log("向下", selectedIndex);
+        if (selectedIndex !== sessions.length - 1) {
+          selectSession(selectedIndex + 1);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedIndex, sessions]);
 
   return (
     <DragDropContext onDragEnd={onDragEnd}>

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -515,7 +515,9 @@ export function Chat() {
       }
     };
 
-    getInputByKey(e.key);
+    if (!promptHints.length) {
+      getInputByKey(e.key);
+    }
 
     if (shouldSubmit(e)) {
       onUserSubmit();

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -53,7 +53,7 @@ import chatStyle from "./chat.module.scss";
 
 import { ListItem, Modal, showModal } from "./ui-lib";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Path } from "../constant";
+import { Path, SlotID } from "../constant";
 import { Avatar } from "./emoji";
 import { MaskAvatar, MaskConfig } from "./mask";
 import { useMaskStore } from "../store/mask";
@@ -492,7 +492,11 @@ export function Chat() {
   // check if should send message
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // if ArrowUp and no userInput
-    if (e.key === "ArrowUp" && userInput.length <= 0) {
+    if (
+      !(e.metaKey || e.ctrlKey) &&
+      e.key === "ArrowUp" &&
+      userInput.length <= 0
+    ) {
       setUserInput(beforeInput);
       e.preventDefault();
       return;
@@ -801,6 +805,7 @@ export function Chat() {
         />
         <div className={styles["chat-input-panel-inner"]}>
           <textarea
+            id={SlotID.chatInput}
             ref={inputRef}
             className={styles["chat-input"]}
             placeholder={Locale.Chat.Input(submitKey)}

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback } from "use-debounce";
-import { useState, useRef, useEffect, useLayoutEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useLayoutEffect } from "react";
 
 import SendWhiteIcon from "../icons/send-white.svg";
 import BrainIcon from "../icons/brain.svg";
@@ -483,7 +483,7 @@ export function Chat() {
     if (userInput.trim() === "") return;
     setIsLoading(true);
     chatStore.onUserInput(userInput).then(() => setIsLoading(false));
-    setBeforeInputIndex(userMessageList.length + 1);
+    setBeforeInput(userInput);
     setUserInput("");
     setPromptHints([]);
     if (!isMobileScreen) inputRef.current?.focus();
@@ -497,28 +497,12 @@ export function Chat() {
 
   // check if should send message
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const getInputByKey = (key: string) => {
-      if (key === "ArrowUp" || key === "ArrowDown") {
-        setBeforeInputIndex((index) => {
-          let newIndex = 0;
-          if (key === "ArrowUp") {
-            newIndex = +index ? index - 1 : index;
-          }
-          if (e.key === "ArrowDown") {
-            newIndex = index < userMessageList.length - 1 ? index + 1 : index;
-          }
-          setUserInput(userMessageList[newIndex]?.content || "");
-          return newIndex;
-        });
-        e.preventDefault();
-        return;
-      }
-    };
-
-    if (!promptHints.length) {
-      getInputByKey(e.key);
+    // if ArrowUp and no userInput
+    if (e.key === "ArrowUp" && userInput.length <= 0) {
+      setUserInput(beforeInput);
+      e.preventDefault();
+      return;
     }
-
     if (shouldSubmit(e)) {
       onUserSubmit();
       e.preventDefault();
@@ -620,26 +604,6 @@ export function Chat() {
           ]
         : [],
     );
-  const userMessageList = useMemo(() => {
-    return messages
-      .filter((m) => m.role === "user")
-      .filter((m) => !m.preview)
-      .map((m, i) => {
-        return {
-          ...m,
-          uid: `${m?.id ? m?.id : Date.now() + Math.random()}_${i}`,
-        };
-      });
-  }, [messages]);
-  const [beforeInputIndex, setBeforeInputIndex] = useState(
-    userMessageList.length,
-  );
-  // Update beforeInputIndex when sessionIndex changes
-  useEffect(() => {
-    if (sessionIndex >= 0) {
-      setBeforeInputIndex(userMessageList.length);
-    }
-  }, [sessionIndex, userMessageList.length]);
 
   const [showPromptModal, setShowPromptModal] = useState(false);
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -17,6 +17,7 @@ export enum Path {
 
 export enum SlotID {
   AppBody = "app-body",
+  chatInput = "chat-textArea-input",
 }
 
 export enum FileName {


### PR DESCRIPTION
类似微信一样 
当满足未有输入框激活，且激活的输入框是输入聊天的`textarea`则可以快递切换，如下gif所示：
在mac 使用` command + ↑`跟` command + ↓`切换聊天窗口
在window 使用`ctrl+ ↑`跟` ctrl + ↓`切换聊天窗口
![2023-05-09_18 04 41](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/63382474/435609e0-dc6b-4aa1-b6d5-2d9a881b4cb3)
