### PR TITLE
fix: the row number counting logic of the textarea 

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -92,6 +92,7 @@ export function useWindowSize() {
 }
 
 export const MOBILE_MAX_WIDTH = 600;
+
 export function useMobileScreen() {
   const { width } = useWindowSize();
 
@@ -160,15 +161,13 @@ export function autoGrowTextArea(dom: HTMLTextAreaElement) {
   measureDom.style.width = width + "px";
   measureDom.innerText = dom.value.trim().length > 0 ? dom.value : "1";
 
-  const lineWrapCount = Math.max(0, dom.value.split("\n").length - 1);
   const height = parseFloat(window.getComputedStyle(measureDom).height);
   const singleLineHeight = parseFloat(
     window.getComputedStyle(singleLineDom).height,
   );
 
-  const rows = Math.round(height / singleLineHeight) + lineWrapCount;
-
-  return rows;
+  const endWithLineBreaker = dom.value.endsWith("\n");
+  return Math.round(height / singleLineHeight) + (endWithLineBreaker ? 1 : 0);
 }
 
 export function getCSSVar(varName: string) {


### PR DESCRIPTION
![image](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/f77e25ae-150d-489f-b7c3-9da8e315f5c6)

as in the snapshot, if you input some content (in my example i used `111` ) with a line breaker for each line, you can find the row num of the textarea increases too many, resulting a tall blank area under the cursor point.  I checked the logic, finding actually it only needs to add 1 to the total row number only if the user's input is ending with `\n`.

