### PR TITLE
Fix: click the prompt button to hide hints when it's already shown

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -789,6 +789,12 @@ export function Chat() {
           scrollToBottom={scrollToBottom}
           hitBottom={hitBottom}
           showPromptHints={() => {
+            // Click again to close
+            if (promptHints.length > 0) {
+              setPromptHints([]);
+              return;
+            }
+
             inputRef.current?.focus();
             onSearch("");
           }}


### PR DESCRIPTION
Allow users to click the prompt hints button to hide hints when they are already displayed.