### PR TITLE
fix: the theme-color selector

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -64,17 +64,17 @@ export function useSwitchTheme() {
     }
 
     const metaDescriptionDark = document.querySelector(
-      'meta[name="theme-color"][media]',
+      'meta[name="theme-color"][media*="dark"]',
     );
     const metaDescriptionLight = document.querySelector(
-      'meta[name="theme-color"]:not([media])',
+      'meta[name="theme-color"][media*="light"]',
     );
 
     if (config.theme === "auto") {
       metaDescriptionDark?.setAttribute("content", "#151515");
       metaDescriptionLight?.setAttribute("content", "#fafafa");
     } else {
-      const themeColor = getCSSVar("--themeColor");
+      const themeColor = getCSSVar("--theme-color");
       metaDescriptionDark?.setAttribute("content", themeColor);
       metaDescriptionLight?.setAttribute("content", themeColor);
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,11 +9,19 @@ const buildConfig = getBuildConfig();
 export const metadata = {
   title: "ChatGPT Next Web",
   description: "Your personal ChatGPT Chat Bot.",
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    maximumScale: 1,
+  },
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fafafa" },
+    { media: "(prefers-color-scheme: dark)", color: "#151515" },
+  ],
   appleWebApp: {
     title: "ChatGPT Next Web",
     statusBarStyle: "default",
   },
-  viewport: "width=device-width, initial-scale=1, maximum-scale=1",
 };
 
 export default function RootLayout({
@@ -24,22 +32,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta
-          name="theme-color"
-          content="#fafafa"
-          media="(prefers-color-scheme: light)"
-        />
-        <meta
-          name="theme-color"
-          content="#151515"
-          media="(prefers-color-scheme: dark)"
-        />
         <meta name="version" content={buildConfig.commitId} />
         <link rel="manifest" href="/site.webmanifest"></link>
         <link rel="preconnect" href="https://fonts.proxy.ustclug.org"></link>
         <link
-          href="https://fonts.proxy.ustclug.org/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap"
           rel="stylesheet"
+          href="https://fonts.proxy.ustclug.org/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap"
         ></link>
         <script src="/serviceWorkerRegister.js" defer></script>
       </head>


### PR DESCRIPTION
theme-color增加了 [media="(prefers-color-scheme: light)](https://github.com/Yidadaa/ChatGPT-Next-Web/commit/36adfe87fb965120a208df907a609ec235437d06#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR30) 这个媒体查询后破坏了之前的 theme-color 查询规则，这个pr主要是修复了查询规则，然后把部分nextjs支持的meta标签移到了`metadata`中（如果需要之前的风格写法可以回退）