### PR TITLE
Fix: enter key to select prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,3 @@ public/prompts.json
 
 .vscode
 .idea
-
-# Other Package Manager
-pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ public/prompts.json
 
 .vscode
 .idea
+
+# Other Package Manager
+pnpm-lock.yaml

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -502,7 +502,7 @@ export function Chat() {
       e.preventDefault();
       return;
     }
-    if (shouldSubmit(e)) {
+    if (shouldSubmit(e) && promptHints.length === 0) {
       doSubmit(userInput);
       e.preventDefault();
     }


### PR DESCRIPTION
When set `enter` key to sumbit message, we cannot press `enter` to select prompt before.