### PR TITLE
fix: set openWhenHidden to be true

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -126,6 +126,7 @@ export class ChatGPTApi implements LLMApi {
           onerror(e) {
             options.onError?.(e);
           },
+          openWhenHidden: true,
         });
       } else {
         const res = await fetch(chatPath, chatPayload);


### PR DESCRIPTION
deep in the source code of [fetch-event-source](https://github.com/Azure/fetch-event-source) , (not the readme markdown document). you can find something [here](https://github.com/Azure/fetch-event-source/blob/a0529492576e094374602f24d5e64b3a271b4576/src/fetch.ts#L50): 
```
    /**
     * If true, will keep the request open even if the document is hidden.
     * By default, fetchEventSource will close the request and reopen it
     * automatically when the document becomes visible again.
     */
    openWhenHidden?: boolean;

```
_Sorry for I didn't know how to embed multi lines of code from another online file, I'd be glad if anybody can give me some hints or tips to do so._

this is much like [TanStack Query](https://tanstack.com/query/v3/) or  [SWR](https://swr.vercel.app/)
which stops http fetching while the browser tab is hidden (shift to be inactive, to back). and restart to fetch data when current tab is shifted back. I personally believe this is a great feature for most scenarios fetching short responses to do cache and revalidate cache. but not the case for a long streaming response..  so the solution to it is to set `openWhenHidden: true`, this makes it continue loading long contents without interruptions even if current tab is shifted back and forth.

This PR fixes the bug reported in https://github.com/Yidadaa/ChatGPT-Next-Web/issues/1566