### PR TITLE
misc: 聊天页面一些样式修改

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -58,6 +58,7 @@ import { Avatar } from "./emoji";
 import { MaskAvatar, MaskConfig } from "./mask";
 import { useMaskStore } from "../store/mask";
 import { useCommand } from "../command";
+import { log } from "console";
 
 const Markdown = dynamic(async () => (await import("./markdown")).Markdown, {
   loading: () => <LoadingIcon />,
@@ -721,68 +722,72 @@ export function Chat() {
               }
             >
               <div className={styles["chat-message-container"]}>
-                <div className={styles["chat-message-avatar"]}>
-                  {message.role === "user" ? (
-                    <Avatar avatar={config.avatar} />
-                  ) : (
-                    <MaskAvatar mask={session.mask} />
-                  )}
-                </div>
-                {showTyping && (
-                  <div className={styles["chat-message-status"]}>
-                    {Locale.Chat.Typing}
+                <div className={styles["chat-message-box"]}>
+                  <div className={styles["chat-message-avatar"]}>
+                    {message.role === "user" ? (
+                      <Avatar avatar={config.avatar} />
+                    ) : (
+                      <MaskAvatar mask={session.mask} />
+                    )}
                   </div>
-                )}
-                <div className={styles["chat-message-item"]}>
-                  {showActions && (
-                    <div className={styles["chat-message-top-actions"]}>
-                      {message.streaming ? (
-                        <div
-                          className={styles["chat-message-top-action"]}
-                          onClick={() => onUserStop(message.id ?? i)}
-                        >
-                          {Locale.Chat.Actions.Stop}
-                        </div>
-                      ) : (
-                        <>
-                          <div
-                            className={styles["chat-message-top-action"]}
-                            onClick={() => onDelete(message.id ?? i)}
-                          >
-                            {Locale.Chat.Actions.Delete}
-                          </div>
-                          <div
-                            className={styles["chat-message-top-action"]}
-                            onClick={() => onResend(message.id ?? i)}
-                          >
-                            {Locale.Chat.Actions.Retry}
-                          </div>
-                        </>
-                      )}
-
-                      <div
-                        className={styles["chat-message-top-action"]}
-                        onClick={() => copyToClipboard(message.content)}
-                      >
-                        {Locale.Chat.Actions.Copy}
-                      </div>
+                  {showTyping && (
+                    <div className={styles["chat-message-status"]}>
+                      {Locale.Chat.Typing}
                     </div>
                   )}
-                  <Markdown
-                    content={message.content}
-                    loading={
-                      (message.preview || message.content.length === 0) &&
-                      !isUser
-                    }
-                    onContextMenu={(e) => onRightClick(e, message)}
-                    onDoubleClickCapture={() => {
-                      if (!isMobileScreen) return;
-                      setUserInput(message.content);
-                    }}
-                    fontSize={fontSize}
-                    parentRef={scrollRef}
-                    defaultShow={i >= messages.length - 10}
-                  />
+                  {!showTyping && (
+                    <div className={styles["chat-message-item"]}>
+                      {showActions && (
+                        <div className={styles["chat-message-top-actions"]}>
+                          {message.streaming ? (
+                            <div
+                              className={styles["chat-message-top-action"]}
+                              onClick={() => onUserStop(message.id ?? i)}
+                            >
+                              {Locale.Chat.Actions.Stop}
+                            </div>
+                          ) : (
+                            <>
+                              <div
+                                className={styles["chat-message-top-action"]}
+                                onClick={() => onDelete(message.id ?? i)}
+                              >
+                                {Locale.Chat.Actions.Delete}
+                              </div>
+                              <div
+                                className={styles["chat-message-top-action"]}
+                                onClick={() => onResend(message.id ?? i)}
+                              >
+                                {Locale.Chat.Actions.Retry}
+                              </div>
+                            </>
+                          )}
+
+                          <div
+                            className={styles["chat-message-top-action"]}
+                            onClick={() => copyToClipboard(message.content)}
+                          >
+                            {Locale.Chat.Actions.Copy}
+                          </div>
+                        </div>
+                      )}
+                      <Markdown
+                        content={message.content}
+                        loading={
+                          (message.preview || message.content.length === 0) &&
+                          !isUser
+                        }
+                        onContextMenu={(e) => onRightClick(e, message)}
+                        onDoubleClickCapture={() => {
+                          if (!isMobileScreen) return;
+                          setUserInput(message.content);
+                        }}
+                        fontSize={fontSize}
+                        parentRef={scrollRef}
+                        defaultShow={i >= messages.length - 10}
+                      />
+                    </div>
+                  )}
                 </div>
                 {!isUser && !message.preview && (
                   <div className={styles["chat-message-actions"]}>

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -365,7 +365,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin-top: 20px;
+  padding-top: 20px;
   &:hover {
     .chat-message-top-actions {
       opacity: 1;

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -381,6 +381,7 @@
 .chat-message-box {
   display: flex;
   width: 100%;
+  overflow: auto;
 }
 .chat-message-box .chat-message-avatar {
   margin: 0 10px 0 0;
@@ -413,6 +414,7 @@
   word-break: break-word;
   border: var(--border-in-light);
   position: relative;
+  overflow: auto;
 }
 
 .chat-message-top-actions {

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -365,7 +365,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-
+  margin-top: 20px;
   &:hover {
     .chat-message-top-actions {
       opacity: 1;
@@ -378,7 +378,18 @@
 .chat-message-user > .chat-message-container {
   align-items: flex-end;
 }
-
+.chat-message-box {
+  display: flex;
+}
+.chat-message-box .chat-message-avatar{
+  margin: 0 10px 0 0;
+}
+.chat-message-user .chat-message-box .chat-message-avatar{
+  margin: 0 0 0 10px;
+}
+.chat-message-user  .chat-message-box {
+  flex-direction: row-reverse;
+}
 .chat-message-avatar {
   margin-top: 20px;
 }
@@ -393,7 +404,6 @@
 .chat-message-item {
   box-sizing: border-box;
   max-width: 100%;
-  margin-top: 10px;
   border-radius: 10px;
   background-color: rgba(0, 0, 0, 0.05);
   padding: 10px;

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -361,7 +361,7 @@
 }
 
 .chat-message-container {
-  max-width: var(--message-max-width);
+ width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -380,6 +380,7 @@
 }
 .chat-message-box {
   display: flex;
+  max-width: var(--message-max-width)
 }
 .chat-message-box .chat-message-avatar{
   margin: 0 10px 0 0;

--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -361,7 +361,7 @@
 }
 
 .chat-message-container {
- width: 100%;
+  max-width: var(--message-max-width);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -380,15 +380,15 @@
 }
 .chat-message-box {
   display: flex;
-  max-width: var(--message-max-width)
+  width: 100%;
 }
-.chat-message-box .chat-message-avatar{
+.chat-message-box .chat-message-avatar {
   margin: 0 10px 0 0;
 }
-.chat-message-user .chat-message-box .chat-message-avatar{
+.chat-message-user .chat-message-box .chat-message-avatar {
   margin: 0 0 0 10px;
 }
-.chat-message-user  .chat-message-box {
+.chat-message-user .chat-message-box {
   flex-direction: row-reverse;
 }
 .chat-message-avatar {


### PR DESCRIPTION
1.聊天对话 头像与文本平行
![微信截图_20230518135554](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/70319988/39307db5-2044-4ab9-a187-5510694d4fad)

2.未发送消息不再聊天框展示
![qwe](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/70319988/699da02c-f988-4074-b5fd-212232121d5c)

这样看着应该比较舒服一些