### PR TITLE
fix: allow to import a single mask

### DIFF
--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -256,6 +256,11 @@ export function MaskPage() {
               maskStore.create(mask);
             }
           }
+          return;
+        }
+        //if the content is a single mask.
+        if (importMasks.name) {
+          maskStore.create(importMasks);
         }
       } catch {}
     });


### PR DESCRIPTION
As discussed in this ticket https://github.com/Yidadaa/ChatGPT-Next-Web/issues/1620

the original logic only supported uploading many  masks, i mean the json content of the uploading file must be in the format of array, but it ignored if the user uploads a single mask.
now I fixed the logic to support both cases. Please review the original ticket to make sure whether this PR should be merged.