### PR TITLE
fix: get real-ip instead of vercel edge network ip

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,24 @@
 {
     "github": {
         "silent": true
-    }
+    },
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers": [
+                {
+                    "key": "X-Real-IP",
+                    "value": "$remote_addr"
+                },
+                {
+                    "key": " X-Forwarded-For",
+                    "value": "$proxy_add_x_forwarded_for"
+                },
+                {
+                    "key": "Host",
+                    "value": "$http_host"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
使用logflare等第三方日志服务的access log中访客IP都是Vercel边缘网络的ip
添加headers以得到真实访客ip。