### PR TITLE
fix: css on display chat names

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -176,7 +176,7 @@
   font-size: 14px;
   font-weight: bolder;
   display: block;
-  width: 200px;
+  width: calc(100% - 15px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
this is a rather minor fix, but it resolves two issues in the UI of sidebar as in below snapshot:

![before](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/c33d9517-e3b3-4226-b21a-93919abc8a81)

1. if the content of the title is longer than 200px, it cannot fully display, regardless how rightwards you drag the sidebar.
2. if you narrow down the sidebar, you may find that the delete icon overlaps with the title.

the result after fix can be seen here:

![after](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/857c4374-bc18-445d-b616-ed95848c6a75)

There is a open pull request https://github.com/Yidadaa/ChatGPT-Next-Web/pull/1320 which addresses the display of title content. but in which it didn't fix the issue of 2.  so I open this PR here.

To create the long chat title, I used these questions:
```
1. what is setTimeout in javascript?
2. how far from Beijing to Tianjin?
```
