### PR TITLE
feat: better mobile icon layout for chat

### DIFF
--- a/app/components/chat.module.scss
+++ b/app/components/chat.module.scss
@@ -27,7 +27,7 @@
 .prompt-toast {
   position: absolute;
   bottom: -50px;
-  z-index: 999;
+  z-index: 998;
   display: flex;
   justify-content: center;
   width: calc(100% - 40px);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -14,7 +14,7 @@ import MaskIcon from "../icons/mask.svg";
 import MaxIcon from "../icons/max.svg";
 import MinIcon from "../icons/min.svg";
 import ResetIcon from "../icons/reload.svg";
-
+import MenuIcon from "../icons/menu.svg";
 import LightIcon from "../icons/light.svg";
 import DarkIcon from "../icons/dark.svg";
 import AutoIcon from "../icons/auto.svg";
@@ -51,7 +51,7 @@ import { IconButton } from "./button";
 import styles from "./home.module.scss";
 import chatStyle from "./chat.module.scss";
 
-import { ListItem, Modal, showModal } from "./ui-lib";
+import { ListItem, Modal, Popover, showModal } from "./ui-lib";
 import { useLocation, useNavigate } from "react-router-dom";
 import { LAST_INPUT_KEY, Path, REQUEST_TIMEOUT_MS } from "../constant";
 import { Avatar } from "./emoji";
@@ -637,9 +637,27 @@ export function Chat() {
     },
   });
 
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const toggleMobileMenu = () => {
+    setMobileMenuOpen(!mobileMenuOpen);
+  };
+
   return (
     <div className={styles.chat} key={session.id}>
       <div className="window-header">
+        {isMobileScreen && (
+          <div className="window-actions">
+            <div className={`window-action-button-mr ${styles["mobile"]}`}>
+              <IconButton
+                icon={<ReturnIcon />}
+                bordered
+                title={Locale.Chat.Actions.ChatList}
+                onClick={() => navigate(Path.Home)}
+              />
+            </div>
+          </div>
+        )}
         <div className="window-header-title">
           <div
             className={`window-header-main-title " ${styles["chat-body-title"]}`}
@@ -652,46 +670,77 @@ export function Chat() {
           </div>
         </div>
         <div className="window-actions">
-          <div className={"window-action-button" + " " + styles.mobile}>
-            <IconButton
-              icon={<ReturnIcon />}
-              bordered
-              title={Locale.Chat.Actions.ChatList}
-              onClick={() => navigate(Path.Home)}
-            />
-          </div>
-          <div className="window-action-button">
-            <IconButton
-              icon={<RenameIcon />}
-              bordered
-              onClick={renameSession}
-            />
-          </div>
-          <div className="window-action-button">
-            <IconButton
-              icon={<ExportIcon />}
-              bordered
-              title={Locale.Chat.Actions.Export}
-              onClick={() => {
-                exportMessages(
-                  session.messages.filter((msg) => !msg.isError),
-                  session.topic,
-                );
-              }}
-            />
-          </div>
-          {!isMobileScreen && (
-            <div className="window-action-button">
-              <IconButton
-                icon={config.tightBorder ? <MinIcon /> : <MaxIcon />}
-                bordered
-                onClick={() => {
-                  config.update(
-                    (config) => (config.tightBorder = !config.tightBorder),
-                  );
-                }}
-              />
-            </div>
+          {!isMobileScreen ? (
+            <>
+              <div className="window-action-button-ml">
+                <IconButton
+                  icon={<RenameIcon />}
+                  bordered
+                  onClick={renameSession}
+                />
+              </div>
+              <div className="window-action-button-ml">
+                <IconButton
+                  icon={<ExportIcon />}
+                  bordered
+                  title={Locale.Chat.Actions.Export}
+                  onClick={() => {
+                    exportMessages(
+                      session.messages.filter((msg) => !msg.isError),
+                      session.topic,
+                    );
+                  }}
+                />
+              </div>
+              <div className="window-action-button-ml">
+                <IconButton
+                  icon={config.tightBorder ? <MinIcon /> : <MaxIcon />}
+                  bordered
+                  onClick={() => {
+                    config.update(
+                      (config) => (config.tightBorder = !config.tightBorder),
+                    );
+                  }}
+                />
+              </div>
+            </>
+          ) : (
+            <Popover
+              open={mobileMenuOpen}
+              onClose={toggleMobileMenu}
+              content={
+                <>
+                  <div className="window-action-button-mb">
+                    <IconButton
+                      icon={<RenameIcon />}
+                      bordered
+                      onClick={renameSession}
+                    />
+                  </div>
+                  <div className="window-action-button-mb">
+                    <IconButton
+                      icon={<ExportIcon />}
+                      bordered
+                      title={Locale.Chat.Actions.Export}
+                      onClick={() => {
+                        exportMessages(
+                          session.messages.filter((msg) => !msg.isError),
+                          session.topic,
+                        );
+                      }}
+                    />
+                  </div>
+                </>
+              }
+            >
+              <div className="window-action-button-ml">
+                <IconButton
+                  icon={<MenuIcon />}
+                  bordered
+                  onClick={toggleMobileMenu}
+                />
+              </div>
+            </Popover>
           )}
         </div>
 

--- a/app/components/ui-lib.module.scss
+++ b/app/components/ui-lib.module.scss
@@ -9,7 +9,7 @@
 
 .popover {
   position: relative;
-  z-index: 2;
+  z-index: 999;
 }
 
 .popover-content {
@@ -25,6 +25,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
+  z-index: -1;
 }
 
 .list-item {

--- a/app/styles/window.scss
+++ b/app/styles/window.scss
@@ -12,6 +12,10 @@
   max-width: calc(100% - 100px);
   overflow: hidden;
 
+  @media screen and (max-width: 600px) {
+      text-align: center;
+    }
+
   .window-header-main-title {
     font-size: 20px;
     font-weight: bolder;
@@ -32,6 +36,20 @@
   display: inline-flex;
 }
 
+// for settings, preset masks ...
 .window-action-button {
   margin-left: 10px;
+}
+
+// for chat
+.window-action-button-ml {
+  margin-left: 10px;
+}
+
+.window-action-button-mr {
+  margin-right: 10px;
+}
+
+.window-action-button-mb {
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
对移动端进行了以下修改：
- 聊天界面将返回按钮防止左边
- 居中标题文字
- 用Popover组件以菜单的形式展开其他按钮

备注：调整了Popover的z-index因为Toast会挡住部分展开的按钮
![image](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/78383353/7c6dee70-afba-4665-b272-a8e86dcafb1d)

