### PR TITLE
Not to detect user lang when running in Node

### DIFF
--- a/app/locales/index.ts
+++ b/app/locales/index.ts
@@ -66,6 +66,9 @@ function setItem(key: string, value: string) {
 }
 
 function getLanguage() {
+  if (typeof process === "object") {
+    return DEFAULT_LANG;
+  }
   try {
     return navigator.language.toLowerCase();
   } catch {


### PR DESCRIPTION
Use DEFAULT_LANG with Node. Remove the logging on the server side:

[Lang] failed to detect user lang.