### PR TITLE
fix: bug #1662

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -271,7 +271,7 @@ export function PromptHints(props: {
 
     return () => window.removeEventListener("keydown", onKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [noPrompts, selectIndex]);
+  }, [props.prompts.length, selectIndex]);
 
   if (noPrompts) return null;
   return (


### PR DESCRIPTION
As in the commit, `props.prompts.length` should be monitored in `useEfffect`, otherwise, when search prompt action changes the length of `props.prompts`, the function inside `useEfffect` doesn't re-generate at all, which still points to the initial props.prompts,  thus the bug comes out..