### PR TITLE
clean next.config.mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   async rewrites() {
     const ret = [
       {


### PR DESCRIPTION
appDir option no longer needed start from nextjs13.4 https://nextjs.org/docs/app/api-reference/next-config-js/appDir