### PR TITLE
fix vercel X-Forwarded-For headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
                     "value": "$remote_addr"
                 },
                 {
-                    "key": " X-Forwarded-For",
+                    "key": "X-Forwarded-For",
                     "value": "$proxy_add_x_forwarded_for"
                 },
                 {


### PR DESCRIPTION
Vercel Log:
Skipping HTTP request header: " x-forwarded-for: $proxy_add_x_forwarded_for"
Header name must be a valid HTTP token [" x-forwarded-for"]

There was an extra space in front of x-forwarded-for, and the bug has been fixed now.