### PR TITLE
fix : specify the default hostname if docker builds with a proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ COPY --from=builder /app/.next/server ./.next/server
 EXPOSE 3000
 
 CMD if [ -n "$PROXY_URL" ]; then \
-        if [ -z "$HOSTNAME" ]; then
-          HOSTNAME="127.0.0.1"
+        if [ -z "$HOSTNAME" ]; then \
+          export HOSTNAME="127.0.0.1" \
         fi; \
         protocol=$(echo $PROXY_URL | cut -d: -f1); \
         host=$(echo $PROXY_URL | cut -d/ -f3 | cut -d: -f1); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ COPY --from=builder /app/.next/server ./.next/server
 EXPOSE 3000
 
 CMD if [ -n "$PROXY_URL" ]; then \
+        if [ -z "$HOSTNAME" ]; then
+          HOSTNAME="127.0.0.1"
+        fi; \
         protocol=$(echo $PROXY_URL | cut -d: -f1); \
         host=$(echo $PROXY_URL | cut -d/ -f3 | cut -d: -f1); \
         port=$(echo $PROXY_URL | cut -d: -f3); \

--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -1,7 +1,10 @@
 export function prettyObject(msg: any) {
+  const obj = msg;
   if (typeof msg !== "string") {
     msg = JSON.stringify(msg, null, "  ");
   }
-  const prettyMsg = ["```json", msg, "```"].join("\n");
-  return prettyMsg;
+  if (msg === "{}") {
+    return obj.toString();
+  }
+  return ["```json", msg, "```"].join("\n");
 }


### PR DESCRIPTION
 修复了部分情况下prettyObject方法存在入参非 string 然而 JSON.stringify 结果为{}的情况 #1732 

Docker 构建时如若存在PROXY_URL环境变量并且未指定 HOSTNAME 则 默认设置为 127.0.0.1以避免 proxychains 代理本机地址 #1556