### PR TITLE
refactor: Fix undefined className in ListItem

### DIFF
--- a/app/components/ui-lib.tsx
+++ b/app/components/ui-lib.tsx
@@ -42,7 +42,7 @@ export function ListItem(props: {
   className?: string;
 }) {
   return (
-    <div className={styles["list-item"] + ` ${props.className}`}>
+    <div className={styles["list-item"] + ` ${props.className || ""}`}>
       <div className={styles["list-header"]}>
         {props.icon && <div className={styles["list-icon"]}>{props.icon}</div>}
         <div className={styles["list-item-title"]}>


### PR DESCRIPTION
解决ListItem组件className出现undefined的问题
<img width="1115" alt="image" src="https://github.com/Yidadaa/ChatGPT-Next-Web/assets/63382474/be1f42d6-cf8c-439f-88fa-d51c54995671">
