### PR TITLE
fix: Logical corrections & syntax errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,7 @@ COPY --from=builder /app/.next/server ./.next/server
 EXPOSE 3000
 
 CMD if [ -n "$PROXY_URL" ]; then \
-        if [ -z "$HOSTNAME" ]; then \
-          export HOSTNAME="127.0.0.1"; \
-        fi; \
+        export HOSTNAME="127.0.0.1"; \
         protocol=$(echo $PROXY_URL | cut -d: -f1); \
         host=$(echo $PROXY_URL | cut -d/ -f3 | cut -d: -f1); \
         port=$(echo $PROXY_URL | cut -d: -f3); \


### PR DESCRIPTION
修复了 #1747 #1748 所说的语法问题 （ 大意了
以及 `if [ -z "$HOSTNAME" ]; then ` 这个逻辑实际上是无效的，Docker 容器一定会有一个HOSTNAME环境变量，所以移除了判断是否不存在的逻辑