### PR TITLE
feat: customize Base URL in frontend

### DIFF
--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -53,6 +53,7 @@ export function auth(req: NextRequest) {
     if (apiKey) {
       console.log("[Auth] use system api key");
       req.headers.set("Authorization", `Bearer ${apiKey}`);
+      req.headers.delete("x-base-url");
     } else {
       console.log("[Auth] admin did not provide an api key");
     }

--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -13,7 +13,7 @@ export async function requestOpenai(req: NextRequest) {
     "",
   );
 
-  let baseUrl = BASE_URL;
+  let baseUrl = req.headers.get("x-base-url") ?? BASE_URL;
 
   if (!baseUrl.startsWith("http")) {
     baseUrl = `${PROTOCOL}://${baseUrl}`;

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -117,3 +117,11 @@ export function getHeaders() {
 
   return headers;
 }
+
+export function getBaseUrl() {
+  const accessStore = useAccessStore.getState();
+  let headers: Record<string, string> = {
+    "x-base-url": accessStore.baseUrl,
+  };
+  return headers;
+}

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -1,7 +1,7 @@
 import { REQUEST_TIMEOUT_MS } from "@/app/constant";
 import { useAccessStore, useAppConfig, useChatStore } from "@/app/store";
 
-import { ChatOptions, getHeaders, LLMApi, LLMUsage } from "../api";
+import { ChatOptions, getHeaders, getBaseUrl, LLMApi, LLMUsage } from "../api";
 import Locale from "../../locales";
 import {
   EventStreamContentType,
@@ -60,7 +60,7 @@ export class ChatGPTApi implements LLMApi {
         method: "POST",
         body: JSON.stringify(requestPayload),
         signal: controller.signal,
-        headers: getHeaders(),
+        headers: Object.assign(getHeaders(), getBaseUrl()),
       };
 
       // make a fetch request

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -524,7 +524,7 @@ export function Settings() {
               subTitle={Locale.Settings.BaseUrl.SubTitle}
             >
               <PasswordInput
-                value={accessStore.token}
+                value={accessStore.baseUrl}
                 type="text"
                 placeholder={Locale.Settings.BaseUrl.Placeholder}
                 onChange={(e) => {

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -518,6 +518,22 @@ export function Settings() {
             </ListItem>
           ) : null}
 
+          {!accessStore.hideUserApiKey ? (
+            <ListItem
+              title={Locale.Settings.BaseUrl.Title}
+              subTitle={Locale.Settings.BaseUrl.SubTitle}
+            >
+              <PasswordInput
+                value={accessStore.token}
+                type="text"
+                placeholder={Locale.Settings.BaseUrl.Placeholder}
+                onChange={(e) => {
+                  accessStore.updateBaseUrl(e.currentTarget.value);
+                }}
+              />
+            </ListItem>
+          ) : null}
+
           <ListItem
             title={Locale.Settings.Usage.Title}
             subTitle={

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -145,7 +145,11 @@ const cn = {
       SubTitle: "使用自己的 Key 可绕过密码访问限制",
       Placeholder: "OpenAI API Key",
     },
-
+    BaseUrl: {
+      Title: "Base Url",
+      SubTitle: "设定 API 的 Base Url，默认使用: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "余额查询",
       SubTitle(used: any, total: any) {

--- a/app/locales/cs.ts
+++ b/app/locales/cs.ts
@@ -128,6 +128,12 @@ const cs: LocaleType = {
       SubTitle: "Použitím klíče ignorujete omezení přístupového kódu",
       Placeholder: "Klíč API OpenAI",
     },
+    BaseUrl: {
+      Title: "Základní adresa URL",
+      SubTitle:
+        "Nastavte základní adresu URL API, výchozí hodnota je api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Stav účtu",
       SubTitle(used: any, total: any) {

--- a/app/locales/de.ts
+++ b/app/locales/de.ts
@@ -130,6 +130,12 @@ const de: LocaleType = {
         "Verwenden Sie Ihren Schlüssel, um das Zugangscode-Limit zu ignorieren",
       Placeholder: "OpenAI API-Schlüssel",
     },
+    BaseUrl: {
+      Title: "Basis-URL",
+      SubTitle:
+        "Setzen Sie die Basis-URL für die API fest. Standardmäßig wird api.openai.com verwendet.",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Kontostand",
       SubTitle(used: any, total: any) {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -147,6 +147,11 @@ const en: RequiredLocaleType = {
       SubTitle: "Use your key to ignore access code limit",
       Placeholder: "OpenAI API Key",
     },
+    BaseUrl: {
+      Title: "Base Url",
+      SubTitle: "Set the base url for the API, default to api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Account Balance",
       SubTitle(used: any, total: any) {

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -128,6 +128,12 @@ const es: LocaleType = {
       SubTitle: "Utiliza tu clave para ignorar el límite de código de acceso",
       Placeholder: "Clave de la API de OpenAI",
     },
+    BaseUrl: {
+      Title: "URL base",
+      SubTitle:
+        "Establecer la URL base de la API, por defecto se utiliza: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Saldo de la cuenta",
       SubTitle(used: any, total: any) {

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -131,6 +131,12 @@ const fr: LocaleType = {
       SubTitle: "Utilisez votre clé pour ignorer la limite du code d'accès",
       Placeholder: "Clé OpenAI API",
     },
+    BaseUrl: {
+      Title: "URL de base",
+      SubTitle:
+        "Définir l'URL de base de l'API, par défaut, utilisez : api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Solde du compte",
       SubTitle(used: any, total: any) {

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -129,6 +129,12 @@ const it: LocaleType = {
         "Utilizzare la chiave per ignorare il limite del codice di accesso",
       Placeholder: "OpenAI API Key",
     },
+    BaseUrl: {
+      Title: "URL di base",
+      SubTitle:
+        "Imposta l'URL di base dell'API, di default utilizza: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Bilancio Account",
       SubTitle(used: any, total: any) {

--- a/app/locales/jp.ts
+++ b/app/locales/jp.ts
@@ -130,6 +130,11 @@ const jp: LocaleType = {
       SubTitle: "自分のキーを使用してパスワードアクセス制限を迂回する",
       Placeholder: "OpenAI APIキー",
     },
+    BaseUrl: {
+      Title: "ベースURL",
+      SubTitle: "APIのベースURLを設定し、デフォルトで使用する：api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "残高照会",
       SubTitle(used: any, total: any) {

--- a/app/locales/ko.ts
+++ b/app/locales/ko.ts
@@ -127,6 +127,11 @@ const ko: LocaleType = {
       SubTitle: "액세스 코드 제한을 무시하기 위해 키 사용",
       Placeholder: "OpenAI API 키",
     },
+    BaseUrl: {
+      Title: "기본 URL",
+      SubTitle: "API의 기본 URL을 설정하고 기본값은 api.openai.com입니다.",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "계정 잔액",
       SubTitle(used: any, total: any) {

--- a/app/locales/ru.ts
+++ b/app/locales/ru.ts
@@ -129,6 +129,12 @@ const ru: LocaleType = {
       SubTitle: "Используйте свой ключ, чтобы игнорировать лимит доступа",
       Placeholder: "API ключ OpenAI",
     },
+    BaseUrl: {
+      Title: "Базовый URL",
+      SubTitle:
+        "Настройте базовый URL API. По умолчанию используйте: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Баланс аккаунта",
       SubTitle(used: any, total: any) {

--- a/app/locales/tr.ts
+++ b/app/locales/tr.ts
@@ -128,6 +128,12 @@ const tr: LocaleType = {
       SubTitle: "Erişim kodu sınırını yoksaymak için anahtarınızı kullanın",
       Placeholder: "OpenAI API Anahtarı",
     },
+    BaseUrl: {
+      Title: "Taban URL",
+      SubTitle:
+        "API için taban URL'yi ayarlayın. Varsayılan olarak kullan: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Hesap Bakiyesi",
       SubTitle(used: any, total: any) {

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -125,6 +125,11 @@ const tw: LocaleType = {
       SubTitle: "使用自己的 Key 可規避授權存取限制",
       Placeholder: "OpenAI API Key",
     },
+    BaseUrl: {
+      Title: "Base Url",
+      SubTitle: "設定 API 的 Base Url，預設使用：api.openai.com。",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "帳戶餘額",
       SubTitle(used: any, total: any) {

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -127,6 +127,11 @@ const vi: LocaleType = {
       SubTitle: "Sử dụng khóa của bạn để bỏ qua giới hạn mã truy cập",
       Placeholder: "OpenAI API Key",
     },
+    BaseUrl: {
+      Title: "URL cơ sở",
+      SubTitle: "Cài đặt URL cơ sở API, mặc định sử dụng: api.openai.com",
+      Placeholder: "api.openai.com",
+    },
     Usage: {
       Title: "Hạn mức tài khoản",
       SubTitle(used: any, total: any) {

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -8,6 +8,7 @@ import { ALL_MODELS } from "./config";
 export interface AccessControlStore {
   accessCode: string;
   token: string;
+  baseUrl: string;
 
   needCode: boolean;
   hideUserApiKey: boolean;
@@ -15,6 +16,7 @@ export interface AccessControlStore {
 
   updateToken: (_: string) => void;
   updateCode: (_: string) => void;
+  updateBaseUrl: (_: string) => void;
   enabledAccessControl: () => boolean;
   isAuthorized: () => boolean;
   fetch: () => void;
@@ -27,6 +29,7 @@ export const useAccessStore = create<AccessControlStore>()(
     (set, get) => ({
       token: "",
       accessCode: "",
+      baseUrl: "",
       needCode: true,
       hideUserApiKey: false,
       openaiUrl: "/api/openai/",
@@ -41,6 +44,9 @@ export const useAccessStore = create<AccessControlStore>()(
       },
       updateToken(token: string) {
         set(() => ({ token }));
+      },
+      updateBaseUrl(url: string) {
+        set(() => ({ baseUrl: url }));
       },
       isAuthorized() {
         get().fetch();


### PR DESCRIPTION
This PR adds the ability for users to customize the Base URL in the frontend, allowing them to use different service providers. This provides greater flexibility and choice for users, and makes the application more versatile.

## Change Made
- Add a new setting to the frontend that allows users to specify a custom Base URL.
- Update the code to use the custom Base URL when making requests to the backend.

## TL; DR
- Add the ability to set a BaseUrl on the web client, which is sent to the backend as a header named `x-base-url`. 
- The backend then sends requests to the corresponding BaseUrl based on this header. 
- When the client doesn't set an API key or BaseUrl (i.e. when accessed via code, or when an API key is provided but no Base URL), the server will use the pre-set BaseUrl in the environment variable to send requests to the corresponding address.

![截屏2023-05-28 18 26 36](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/14991225/6e6b5aa8-add8-4f49-b84b-e77857492771)
