### PR TITLE
chore: remove unused code

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -98,13 +98,6 @@ export function useMobileScreen() {
   return width <= MOBILE_MAX_WIDTH;
 }
 
-export function isMobileScreen() {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return window.innerWidth <= MOBILE_MAX_WIDTH;
-}
-
 export function isFirefox() {
   return (
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent)


### PR DESCRIPTION
this PR is to remove a unused function:
```
export function isMobileScreen() {
  if (typeof window === "undefined") {
    return false;
  }
  return window.innerWidth <= MOBILE_MAX_WIDTH;
}
```
because the actual `isMobileScreen` is from  the `useMobileScreen` custom hook. with the same name, this function can be confusing.