### PR TITLE
fix: [CSS] the position of top-action buttons

### DIFF
--- a/app/components/home.module.scss
+++ b/app/components/home.module.scss
@@ -141,7 +141,7 @@
 
 .sidebar-sub-title {
   font-size: 12px;
-  font-weight: 400px;
+  font-weight: 400;
   animation: slide-in ease 0.3s;
 }
 
@@ -369,7 +369,7 @@
   &:hover {
     .chat-message-top-actions {
       opacity: 1;
-      right: 10px;
+      transform: translateX(10px);
       pointer-events: all;
     }
   }
@@ -405,11 +405,12 @@
 }
 
 .chat-message-top-actions {
+  min-width: 120px;
   font-size: 12px;
   position: absolute;
   right: 20px;
   top: -26px;
-  left: 100px;
+  left: 30px;
   transition: all ease 0.3s;
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
actually I've detected this issue for a long while. 
as in this snapshot:
![before](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/e81632a4-fdc1-4b30-a6bf-9eac34d8228f)

when the returned content is too short, the buttons may overlap with the chatbot icon. The question I used for this answer is `reply me yes or no to my question, is 1+1=3?`

After the fix, it becomes:
![after](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/c1fe7cd9-d1e2-43ed-8741-da390be84d4f)
