### PR TITLE
fix: the display format of json error

### DIFF
--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -6,5 +6,8 @@ export function prettyObject(msg: any) {
   if (msg === "{}") {
     return obj.toString();
   }
+  if (msg.startsWith("```json")) {
+    return msg;
+  }
   return ["```json", msg, "```"].join("\n");
 }


### PR DESCRIPTION

![image](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/2328124/cec82ff2-221d-4148-b1fd-460d502bd5fc)

as in the snapshot,  this bug can happen in cases like when the internet is broken, or accessing from China-based IP addresses.
I did a lot of research, finding this fix requires the minimum change of code.