### PR TITLE
feat: wrap input with delimiters

### DIFF
--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -104,6 +104,29 @@ export function MaskConfig(props: {
           ></input>
         </ListItem>
         <ListItem
+          title={Locale.Mask.Config.Delimiters.Title}
+          subTitle={Locale.Mask.Config.Delimiters.SubTitle}
+        >
+          <input
+            type="text"
+            value={props.mask.leftDelimiter}
+            onInput={(e) =>
+              props.updateMask((mask) => {
+                mask.leftDelimiter = e.currentTarget.value;
+              })
+            }
+          ></input>
+          <input
+            type="text"
+            value={props.mask.rightDelimiter}
+            onInput={(e) =>
+              props.updateMask((mask) => {
+                mask.rightDelimiter = e.currentTarget.value;
+              })
+            }
+          ></input>
+        </ListItem>
+        <ListItem
           title={Locale.Mask.Config.HideContext.Title}
           subTitle={Locale.Mask.Config.HideContext.SubTitle}
         >

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -225,6 +225,10 @@ const cn = {
     Config: {
       Avatar: "角色头像",
       Name: "角色名称",
+      Delimiters: {
+        Title: "输入分隔符",
+        SubTitle: "设置分隔符后，用户输入内容会被左右分隔符包裹",
+      },
       Sync: {
         Title: "使用全局设置",
         SubTitle: "当前对话是否使用全局模型设置",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -228,6 +228,11 @@ const en: RequiredLocaleType = {
     Config: {
       Avatar: "Bot Avatar",
       Name: "Bot Name",
+      Delimiters: {
+        Title: "Input Delimiters",
+        SubTitle:
+          "User input will be wrapped by the left and right delimiters if provided",
+      },
       Sync: {
         Title: "Use Global Config",
         SubTitle: "Use global config in this chat",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -238,7 +238,9 @@ export const useChatStore = create<ChatStore>()(
 
         const userMessage: ChatMessage = createMessage({
           role: "user",
-          content,
+          content: `${session.mask.leftDelimiter ?? ""}${content}${
+            session.mask.rightDelimiter ?? ""
+          }`,
         });
 
         const botMessage: ChatMessage = createMessage({

--- a/app/store/mask.ts
+++ b/app/store/mask.ts
@@ -16,6 +16,8 @@ export type Mask = {
   modelConfig: ModelConfig;
   lang: Lang;
   builtin: boolean;
+  leftDelimiter?: string;
+  rightDelimiter?: string;
 };
 
 export const DEFAULT_MASK_STATE = {


### PR DESCRIPTION
在对话设置中添加输入分隔符配置项，当配置了左右分隔符时，所有的用户输入都会用分隔符包裹。同时结合在系统prompt中指定输入分隔符，可以防止用户输入造成上下文逃逸。

支持了吴恩达公开课中的 tactic 1: use delimiters

![Screenshot from 2023-06-02 00-12-39](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/271538/a9350652-f43b-43fa-b3c0-f3ace0144fb5)
