### PR TITLE
fix date time bug on chat lists

### DIFF
--- a/app/components/chat-list.tsx
+++ b/app/components/chat-list.tsx
@@ -72,9 +72,7 @@ export function ChatItem(props: {
                 <div className={styles["chat-item-count"]}>
                   {Locale.ChatItem.ChatItemCount(props.count)}
                 </div>
-                <div className={styles["chat-item-date"]}>
-                  {new Date(props.time).toLocaleString()}
-                </div>
+                <div className={styles["chat-item-date"]}>{props.time}</div>
               </div>
             </>
           )}


### PR DESCRIPTION
props is converted to a string when we create the component, we don't need to do it twice


https://github.com/Yidadaa/ChatGPT-Next-Web/blob/main/app/components/chat-list.tsx#L76