### PR TITLE
feat  新增openai  06-13更新相关模型

### DIFF
--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -73,6 +73,18 @@ export const ALL_MODELS = [
     available: true,
   },
   {
+    name: "gpt-3.5-turbo-16k",
+    available: true,
+  },
+  {
+    name: "gpt-3.5-turbo-0613",
+    available: true,
+  },
+  {
+    name: "gpt-3.5-turbo-16k-0613",
+    available: true,
+  },	
+  {
     name: "gpt-3.5-turbo-0301",
     available: true,
   },


### PR DESCRIPTION
支持gpt-3.5-turbo-16k 模型，相关资料如下：
https://openai.com/blog/function-calling-and-other-api-updates