### PR TITLE
fix: remove selection range when user blured

### DIFF
--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -185,7 +185,11 @@ function ContextPromptItem(props: {
         className={chatStyle["context-content"]}
         rows={focusingInput ? 5 : 1}
         onFocus={() => setFocusingInput(true)}
-        onBlur={() => setFocusingInput(false)}
+        onBlur={() => {
+          setFocusingInput(false);
+          // 如果在用户失去焦点时不清除选区，那么一些依赖类似「划词翻译」的扩展会始终显示浮动条
+          window?.getSelection()?.removeAllRanges();
+        }}
         onInput={(e) =>
           props.update({
             ...props.prompt,

--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -187,7 +187,8 @@ function ContextPromptItem(props: {
         onFocus={() => setFocusingInput(true)}
         onBlur={() => {
           setFocusingInput(false);
-          // 如果在用户失去焦点时不清除选区，那么一些依赖类似「划词翻译」的扩展会始终显示浮动条
+          // If the selection is not removed when the user loses focus, some
+          // extensions like "Translate" will always display a floating bar
           window?.getSelection()?.removeAllRanges();
         }}
         onInput={(e) =>


### PR DESCRIPTION
当用户在`ContextPromptItem`的`Input`触发`blur`事件时，清除所有的`selection range`，避免「划词翻译」这类扩展始终显示浮动条

## before

https://github.com/Yidadaa/ChatGPT-Next-Web/assets/35998162/83284c58-23ca-4f51-9f82-8ca9ad1da1e8

## after

https://github.com/Yidadaa/ChatGPT-Next-Web/assets/35998162/6010a8f8-667a-4f56-9bf8-6e9c525078d6

