### PR TITLE
fix: updating the array using push in zustand does not actually trigger component updates

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -227,6 +227,7 @@ export const useChatStore = create<ChatStore>()(
 
       onNewMessage(message) {
         get().updateCurrentSession((session) => {
+          session.messages = session.messages.concat();
           session.lastUpdate = Date.now();
         });
         get().updateStat(message);
@@ -273,8 +274,9 @@ export const useChatStore = create<ChatStore>()(
 
         // save user's and bot's message
         get().updateCurrentSession((session) => {
-          session.messages.push(userMessage);
-          session.messages.push(botMessage);
+          // session.messages.push(userMessage);
+          // session.messages.push(botMessage);
+          session.messages = session.messages.concat([userMessage, botMessage]);
         });
 
         // make request
@@ -287,7 +289,10 @@ export const useChatStore = create<ChatStore>()(
             if (message) {
               botMessage.content = message;
             }
-            set(() => ({}));
+            // set(() => ({}));
+            get().updateCurrentSession((session) => {
+              session.messages = session.messages.concat();
+            });
           },
           onFinish(message) {
             botMessage.streaming = false;
@@ -299,7 +304,7 @@ export const useChatStore = create<ChatStore>()(
               sessionIndex,
               botMessage.id ?? messageIndex,
             );
-            set(() => ({}));
+            // set(() => ({}));
           },
           onError(error) {
             const isAborted = error.message.includes("aborted");

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -317,8 +317,10 @@ export const useChatStore = create<ChatStore>()(
             botMessage.streaming = false;
             userMessage.isError = !isAborted;
             botMessage.isError = !isAborted;
-
-            set(() => ({}));
+            get().updateCurrentSession((session) => {
+              session.messages = session.messages.concat();
+            });
+            // set(() => ({}));
             ChatControllerPool.remove(
               sessionIndex,
               botMessage.id ?? messageIndex,

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -274,8 +274,6 @@ export const useChatStore = create<ChatStore>()(
 
         // save user's and bot's message
         get().updateCurrentSession((session) => {
-          // session.messages.push(userMessage);
-          // session.messages.push(botMessage);
           session.messages = session.messages.concat([userMessage, botMessage]);
         });
 
@@ -289,7 +287,6 @@ export const useChatStore = create<ChatStore>()(
             if (message) {
               botMessage.content = message;
             }
-            // set(() => ({}));
             get().updateCurrentSession((session) => {
               session.messages = session.messages.concat();
             });
@@ -304,7 +301,6 @@ export const useChatStore = create<ChatStore>()(
               sessionIndex,
               botMessage.id ?? messageIndex,
             );
-            // set(() => ({}));
           },
           onError(error) {
             const isAborted = error.message.includes("aborted");
@@ -320,7 +316,6 @@ export const useChatStore = create<ChatStore>()(
             get().updateCurrentSession((session) => {
               session.messages = session.messages.concat();
             });
-            // set(() => ({}));
             ChatControllerPool.remove(
               sessionIndex,
               botMessage.id ?? messageIndex,


### PR DESCRIPTION
As stated in the documentation, all states in Zustand are immutable. Therefore, when updating arrays or nested objects, it is recommended to use immutable methods. Mutable methods like `Array.prototype.push()` may not be detected by Zustand.

Although mutable methods may still work in practice, issues may arise when using performance optimization techniques such as `useCallback` and `memo`. This suggests that the component render actually caused by parent components, rather than Zustand.

While I am not highly experienced in using Zustand, I personally prefer the immutable approach. If you prefer the mutable approach (as seen in Redux Toolkit), integrating Immer into Zustand may be a viable option.

https://docs.pmnd.rs/zustand/guides/updating-state#normal-approach
https://docs.pmnd.rs/zustand/integrations/immer-middleware