### PR TITLE
Use sweetalert2 to replace `window.prompt` to implement the "Rename Chat" feature.

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1,3 +1,4 @@
+import Swal from "sweetalert2";
 import { useDebouncedCallback } from "use-debounce";
 import React, {
   useState,
@@ -704,8 +705,23 @@ export function Chat() {
 
   const [showPromptModal, setShowPromptModal] = useState(false);
 
-  const renameSession = () => {
-    const newTopic = prompt(Locale.Chat.Rename, session.topic);
+  const renameSession = async () => {
+    const { value: newTopic } = await Swal.fire({
+      title: Locale.Chat.Rename,
+      input: "text",
+      inputValue: session.topic,
+      inputAttributes: {
+        autocapitalize: "off",
+        autocorrect: "off",
+        style: "max-width: 100%",
+      },
+      confirmButtonText: Locale.UI.Confirm,
+      cancelButtonText: Locale.UI.Cancel,
+      showCancelButton: true,
+      background: "var(--white)",
+      color: "var(--black)",
+    });
+
     if (newTopic && newTopic !== session.topic) {
       chatStore.updateCurrentSession((session) => (session.topic = newTopic!));
     }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "remark-math": "^5.1.1",
     "sass": "^1.59.2",
     "spark-md5": "^3.0.2",
+    "sweetalert2": "^11.7.12",
     "use-debounce": "^9.0.4",
     "zustand": "^4.3.8"
   },


### PR DESCRIPTION
- Web版，在Safari浏览器中，“重命名会话”功能的window.prompt对话框，不会随着设置中主题的变化而变化，始终是明亮主题
- 桌面应用版，在macOS系统上，“重命名会话”功能的window.prompt对话框，不会弹出，原因请参考：https://github.com/tauri-apps/tauri/issues/4783
- The web version, in Safari browser, the window.prompt dialog for the "Rename Chat" feature does not change with the theme settings and remains in the light theme.
- The desktop application version, on macOS systems, the window.prompt dialog for the "Rename Chat" feature will not pop up due to a known issue, please refer to: https://github.com/tauri-apps/tauri/issues/4783

[sweetalert2](https://github.com/sweetalert2/sweetalert2)