### PR TITLE
fix: alignment of mobile settings page title.

### DIFF
--- a/app/components/chat.module.scss
+++ b/app/components/chat.module.scss
@@ -218,11 +218,17 @@
   overscroll-behavior: none;
 }
 
-.chat-body-title {
+.chat-body-main-title {
   cursor: pointer;
 
   &:hover {
     text-decoration: underline;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .chat-body-title {
+    text-align: center;
   }
 }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -808,9 +808,9 @@ export function Chat() {
           </div>
         )}
 
-        <div className="window-header-title">
+        <div className={`window-header-title ${styles["chat-body-title"]}`}>
           <div
-            className={`window-header-main-title " ${styles["chat-body-title"]}`}
+            className={`window-header-main-title ${styles["chat-body-main-title"]}`}
             onClickCapture={renameSession}
           >
             {!session.topic ? DEFAULT_TOPIC : session.topic}

--- a/app/components/ui-lib.module.scss
+++ b/app/components/ui-lib.module.scss
@@ -207,7 +207,7 @@
 .select-with-icon {
   position: relative;
   max-width: fit-content;
-  
+
   .select-with-icon-select {
     height: 100%;
     border: var(--border-in-light);

--- a/app/styles/window.scss
+++ b/app/styles/window.scss
@@ -25,10 +25,6 @@
   .window-header-sub-title {
     font-size: 14px;
   }
-
-  @media screen and (max-width: 600px) {
-    text-align: center;
-  }
 }
 
 .window-actions {


### PR DESCRIPTION
移动端设置页面的title不应居中，这个pr不会影响移动端对话页面标题居中的特性。

before：
![25085d6a863eeeb5ba234c475efd805](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/25226871/df752370-61bb-42f4-a638-dbe6ebc8766b)

after:
![c16825ffb7c41df131951add86727e9](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/25226871/ea60165a-30da-4544-bd27-59b8a0335bcd)
