### PR TITLE
feat: add setting to hide built-in masks

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -538,10 +538,12 @@ export function Settings() {
               }
             ></input>
           </ListItem>
+        </List>
 
+        <List>
           <ListItem
-            title={Locale.Settings.Mask.Title}
-            subTitle={Locale.Settings.Mask.SubTitle}
+            title={Locale.Settings.Mask.Splash.Title}
+            subTitle={Locale.Settings.Mask.Splash.SubTitle}
           >
             <input
               type="checkbox"
@@ -551,6 +553,22 @@ export function Settings() {
                   (config) =>
                     (config.dontShowMaskSplashScreen =
                       !e.currentTarget.checked),
+                )
+              }
+            ></input>
+          </ListItem>
+
+          <ListItem
+            title={Locale.Settings.Mask.Builtin.Title}
+            subTitle={Locale.Settings.Mask.Builtin.SubTitle}
+          >
+            <input
+              type="checkbox"
+              checked={!config.dontAddBuiltinMasks}
+              onChange={(e) =>
+                updateConfig(
+                  (config) =>
+                    (config.dontAddBuiltinMasks = !e.currentTarget.checked),
                 )
               }
             ></input>

--- a/app/locales/ar.ts
+++ b/app/locales/ar.ts
@@ -130,8 +130,14 @@ const ar: PartialLocaleType = {
       SubTitle: "معاينة Markdown في فقاعة",
     },
     Mask: {
-      Title: "شاشة تظهر الأقنعة",
-      SubTitle: "عرض شاشة تظهر الأقنعة قبل بدء الدردشة الجديدة",
+      Splash: {
+        Title: "شاشة تظهر الأقنعة",
+        SubTitle: "عرض شاشة تظهر الأقنعة قبل بدء الدردشة الجديدة",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -156,8 +156,14 @@ const cn = {
       SubTitle: "在预览气泡中预览 Markdown 内容",
     },
     Mask: {
-      Title: "面具启动页",
-      SubTitle: "新建聊天时，展示面具启动页",
+      Splash: {
+        Title: "面具启动页",
+        SubTitle: "新建聊天时，展示面具启动页",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/cs.ts
+++ b/app/locales/cs.ts
@@ -87,8 +87,14 @@ const cs: PartialLocaleType = {
       SubTitle: "Zobrazit v náhledu bubliny",
     },
     Mask: {
-      Title: "Úvodní obrazovka Masek",
-      SubTitle: "Před zahájením nového chatu zobrazte úvodní obrazovku Masek",
+      Splash: {
+        Title: "Úvodní obrazovka Masek",
+        SubTitle: "Před zahájením nového chatu zobrazte úvodní obrazovku Masek",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/de.ts
+++ b/app/locales/de.ts
@@ -87,8 +87,14 @@ const de: PartialLocaleType = {
       SubTitle: "Preview markdown in bubble",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Show a mask splash screen before starting new chat",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Show a mask splash screen before starting new chat",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -157,8 +157,14 @@ const en: LocaleType = {
       SubTitle: "Preview markdown in bubble",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Show a mask splash screen before starting new chat",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Show a mask splash screen before starting new chat",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -87,8 +87,14 @@ const es: PartialLocaleType = {
       SubTitle: "Preview markdown in bubble",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Show a mask splash screen before starting new chat",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Show a mask splash screen before starting new chat",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -88,9 +88,15 @@ const fr: PartialLocaleType = {
       SubTitle: "Aperçu du Markdown dans une bulle",
     },
     Mask: {
-      Title: "Écran de masque",
-      SubTitle:
-        "Afficher un écran de masque avant de démarrer une nouvelle discussion",
+      Splash: {
+        Title: "Écran de masque",
+        SubTitle:
+          "Afficher un écran de masque avant de démarrer une nouvelle discussion",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -87,8 +87,14 @@ const it: PartialLocaleType = {
       SubTitle: "Preview markdown in bubble",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Show a mask splash screen before starting new chat",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Show a mask splash screen before starting new chat",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/jp.ts
+++ b/app/locales/jp.ts
@@ -104,8 +104,14 @@ const jp: PartialLocaleType = {
       SubTitle: "プレビューバブルでマークダウンコンテンツをプレビュー",
     },
     Mask: {
-      Title: "キャラクターページ",
-      SubTitle: "新規チャット作成時にキャラクターページを表示する",
+      Splash: {
+        Title: "キャラクターページ",
+        SubTitle: "新規チャット作成時にキャラクターページを表示する",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/ko.ts
+++ b/app/locales/ko.ts
@@ -87,8 +87,14 @@ const ko: PartialLocaleType = {
       SubTitle: "버블에서 마크다운 미리 보기",
     },
     Mask: {
-      Title: "마스크 시작 화면",
-      SubTitle: "새로운 채팅 시작 전에 마스크 시작 화면 표시",
+      Splash: {
+        Title: "마스크 시작 화면",
+        SubTitle: "새로운 채팅 시작 전에 마스크 시작 화면 표시",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/ru.ts
+++ b/app/locales/ru.ts
@@ -87,8 +87,14 @@ const ru: PartialLocaleType = {
       SubTitle: "Предварительный просмотр markdown в пузыре",
     },
     Mask: {
-      Title: "Экран заставки маски",
-      SubTitle: "Показывать экран заставки маски перед началом нового чата",
+      Splash: {
+        Title: "Экран заставки маски",
+        SubTitle: "Показывать экран заставки маски перед началом нового чата",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/tr.ts
+++ b/app/locales/tr.ts
@@ -87,8 +87,14 @@ const tr: PartialLocaleType = {
       SubTitle: "Preview markdown in bubble",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Show a mask splash screen before starting new chat",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Show a mask splash screen before starting new chat",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -85,8 +85,14 @@ const tw: PartialLocaleType = {
       SubTitle: "在预览气泡中预览 Markdown 内容",
     },
     Mask: {
-      Title: "面具启动页",
-      SubTitle: "新建聊天时，展示面具启动页",
+      Splash: {
+        Title: "面具启动页",
+        SubTitle: "新建聊天时，展示面具启动页",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -87,8 +87,14 @@ const vi: PartialLocaleType = {
       SubTitle: "Xem trước nội dung markdown bằng bong bóng",
     },
     Mask: {
-      Title: "Mask Splash Screen",
-      SubTitle: "Chớp màn hình khi bắt đầu cuộc trò chuyện mới",
+      Splash: {
+        Title: "Mask Splash Screen",
+        SubTitle: "Chớp màn hình khi bắt đầu cuộc trò chuyện mới",
+      },
+      Builtin: {
+        Title: "Show Builtin Masks",
+        SubTitle: "Show builtin masks in mask list",
+      },
     },
     Prompt: {
       Disable: {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -29,6 +29,7 @@ export const DEFAULT_CONFIG = {
   disablePromptHint: false,
 
   dontShowMaskSplashScreen: false, // dont show splash screen when create chat
+  dontAddBuiltinMasks: false, // dont add builtin masks
 
   modelConfig: {
     model: "gpt-3.5-turbo" as ModelType,

--- a/app/store/mask.ts
+++ b/app/store/mask.ts
@@ -90,6 +90,7 @@ export const useMaskStore = create<MaskStore>()(
           (a, b) => b.id - a.id,
         );
         const config = useAppConfig.getState();
+        if (config.dontAddBuiltinMasks) return userMasks;
         const buildinMasks = BUILTIN_MASKS.map(
           (m) =>
             ({


### PR DESCRIPTION
This PR adds a setting to hide built-in masks. If activated, only the user-defined masks are shown.