### PR TITLE
修复摘要总结后不会被使用

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -420,7 +420,7 @@ export const useChatStore = create<ChatStore>()(
           modelConfig.sendMemory &&
           session.memoryPrompt &&
           session.memoryPrompt.length > 0 &&
-          session.lastSummarizeIndex <= clearContextIndex;
+          session.lastSummarizeIndex > clearContextIndex;
         const longTermMemoryPrompts = shouldSendLongTermMemory
           ? [get().getMemoryPrompt()]
           : [];


### PR DESCRIPTION
问题描述：摘要总结后并不会被下次对话使用

问题复现：将历史长度压缩阀值调的低一点，方便触发摘要总结，F12 发现摘要总结后的对话并没有带上摘要内容。