### PR TITLE
fix: cloudflare headers

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -35,12 +35,12 @@ export async function requestOpenai(req: NextRequest) {
   const fetchOptions: RequestInit = {
     headers: {
       "Content-Type": "application/json",
+      "Cache-Control": "no-store",
       Authorization: authValue,
       ...(process.env.OPENAI_ORG_ID && {
         "OpenAI-Organization": process.env.OPENAI_ORG_ID,
       }),
     },
-    cache: "no-store",
     method: req.method,
     body: req.body,
     // @ts-ignore


### PR DESCRIPTION
Cloudflare部署时候请求报，"The cache field on RequestInitializerDict is not implemented in fetch"

nodejs原生fetch请求好像不支持cache属性，如有必要通过设置头信息 ‘Cache-Control’ 是否也能达到相同效果