### PR TITLE
支持在设置”隐藏系统预设“时，依旧展示部分预设对话以增强用户体验。

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -854,7 +854,7 @@ export function Chat() {
   };
 
   const context: RenderMessage[] = session.mask.hideContext
-    ? []
+    ? session.mask.context.slice().filter(v => {return v?.forceShow})
     : session.mask.context.slice();
 
   const accessStore = useAccessStore();

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -24,6 +24,7 @@ export type ChatMessage = RequestMessage & {
   isError?: boolean;
   id: string;
   model?: ModelType;
+  forceShow?: boolean;
 };
 
 export function createMessage(override: Partial<ChatMessage>): ChatMessage {


### PR DESCRIPTION
在系统预设面具中，如果开启了”隐藏系统预设“功能，但还想展示部分对话给用户。可以针对某些希望展示出来的预设对话添加`forceShow`属性。