### PR TITLE
font family display enhance

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -104,8 +104,7 @@ const loadAsyncGoogleFont = () => {
     getClientConfig()?.buildMode === "export" ? remoteFontUrl : proxyFontUrl;
   linkEl.rel = "stylesheet";
   linkEl.href =
-    googleFontUrl +
-    "/css2?family=Noto+Sans+SC:wght@300;400;700;900&display=swap";
+    googleFontUrl + "/css2?family=Noto+Sans:wght@300;400;700;900&display=swap";
   document.head.appendChild(linkEl);
 };
 

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -89,7 +89,7 @@
 html {
   height: var(--full-height);
 
-  font-family: "Noto Sans SC", "SF Pro SC", "SF Pro Text", "SF Pro Icons",
+  font-family: "Noto Sans", "SF Pro SC", "SF Pro Text", "SF Pro Icons",
     "PingFang SC", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
 }
 


### PR DESCRIPTION
If we use `Noto Sans SC`, there are display problems when Chinese and English mixed input.
For example:
```
你0 F0
```
There are two different sizes of `0` will be displayed, because we imported multiple font families. 
So I recommend using `Noto Sans` instead of `Noto Sans SC`.