### PR TITLE
Dev title generation option

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -49,6 +49,7 @@ import { Avatar, AvatarPicker } from "./emoji";
 import { getClientConfig } from "../config/client";
 import { useSyncStore } from "../store/sync";
 import { nanoid } from "nanoid";
+import { GENERATE_TITLE_OPTION } from "../constant";
 
 function EditPromptModal(props: { id: string; onClose: () => void }) {
   const promptStore = usePromptStore();
@@ -543,6 +544,30 @@ export function Settings() {
                 )
               }
             ></input>
+          </ListItem>
+        </List>
+
+        <List>
+          <ListItem
+            title={Locale.Settings.GenerateTitle.Title}
+            subTitle={Locale.Settings.GenerateTitle.SubTitle}
+          >
+            <Select
+              value={config.generateTitle.selected}
+              onChange={(e) =>
+                updateConfig(
+                  (config) =>
+                    (config.generateTitle.selected = e.currentTarget
+                      .value as GENERATE_TITLE_OPTION),
+                )
+              }
+            >
+              {Object.values(GENERATE_TITLE_OPTION).map((option) => (
+                <option value={option} key={option}>
+                  {Locale.Settings.GenerateTitle.Options[option]}
+                </option>
+              ))}
+            </Select>
           </ListItem>
         </List>
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -112,3 +112,9 @@ export const DEFAULT_MODELS = [
 
 export const CHAT_PAGE_SIZE = 15;
 export const MAX_RENDER_MSG_COUNT = 45;
+
+export enum GENERATE_TITLE_OPTION {
+  disable = "disable",
+  prompt = "prompt",
+  ai = "ai",
+}

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -114,7 +114,7 @@ export const CHAT_PAGE_SIZE = 15;
 export const MAX_RENDER_MSG_COUNT = 45;
 
 export enum GENERATE_TITLE_OPTION {
-  disable = "disable",
-  prompt = "prompt",
   ai = "ai",
+  prompt = "prompt",
+  disable = "disable",
 }

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -170,6 +170,15 @@ const cn = {
       Title: "预览气泡",
       SubTitle: "在预览气泡中预览 Markdown 内容",
     },
+    GenerateTitle: {
+      Title: "生成标题",
+      SubTitle: "选择一个生成标题的方案",
+      Options: {
+        disable: "关闭",
+        prompt: "用户输入",
+        ai: "AI总结",
+      },
+    },
     Mask: {
       Splash: {
         Title: "面具启动页",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -172,6 +172,15 @@ const en: LocaleType = {
       Title: "Send Preview Bubble",
       SubTitle: "Preview markdown in bubble",
     },
+    GenerateTitle: {
+      Title: "Generate Title",
+      SubTitle: "Choose a title generation option",
+      Options: {
+        disable: "Disable",
+        prompt: "User Prompt",
+        ai: "AI Summary",
+      },
+    },
     Mask: {
       Splash: {
         Title: "Mask Splash Screen",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -273,6 +273,7 @@ export const useChatStore = create<ChatStore>()(
           session.lastUpdate = Date.now();
         });
         get().updateStat(message);
+        get().generateSessionTopicWithAI();
         get().summarizeSession();
       },
 
@@ -534,8 +535,6 @@ export const useChatStore = create<ChatStore>()(
 
         // remove error messages if any
         const messages = session.messages;
-
-        get().generateSessionTopicWithAI();
 
         const modelConfig = session.mask.modelConfig;
         const summarizeIndex = Math.max(

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -93,6 +93,7 @@ interface ChatStore {
   onNewMessage: (message: ChatMessage) => void;
   onUserInput: (content: string) => Promise<void>;
   generateSessionTopicWithAI: () => void;
+  generateSessionTopicWithPrompt: (prompt: string) => void;
   summarizeSession: () => void;
   updateStat: (message: ChatMessage) => void;
   updateCurrentSession: (updater: (session: ChatSession) => void) => void;
@@ -511,6 +512,21 @@ export const useChatStore = create<ChatStore>()(
             },
           });
         }
+      },
+
+      generateSessionTopicWithPrompt(prompt: string) {
+        // The entire user input cannot be used as the title and needs to be truncated.
+        // Possible solutions for future revisions:
+        // 1. Select an appropriate length calculation method, considering the unfairness in counting the length of words and Chinese characters (words usually contain more letters, while Chinese characters can express the same meaning more concisely).
+        // 2. Consider using paragraph symbols (.,。, or other punctuation marks) to divide the input and select the first paragraph block.
+
+        get().updateCurrentSession(
+          (session) =>
+            (session.topic =
+              prompt.length > 0
+                ? trimTopic(prompt).slice(0, 50)
+                : DEFAULT_TOPIC),
+        );
       },
 
       summarizeSession() {

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_INPUT_TEMPLATE,
   DEFAULT_SYSTEM_TEMPLATE,
   StoreKey,
+  GENERATE_TITLE_OPTION,
 } from "../constant";
 import { api, RequestMessage } from "../client/api";
 import { ChatControllerPool } from "../client/controller";
@@ -61,6 +62,8 @@ export const BOT_HELLO: ChatMessage = createMessage({
   role: "assistant",
   content: Locale.Store.BotHello,
 });
+
+const config = useAppConfig.getState();
 
 function createEmptySession(): ChatSession {
   return {
@@ -273,7 +276,11 @@ export const useChatStore = create<ChatStore>()(
           session.lastUpdate = Date.now();
         });
         get().updateStat(message);
-        get().generateSessionTopicWithAI();
+
+        if (config.generateTitle.selected === GENERATE_TITLE_OPTION.ai) {
+          get().generateSessionTopicWithAI();
+        }
+
         get().summarizeSession();
       },
 
@@ -283,6 +290,13 @@ export const useChatStore = create<ChatStore>()(
 
         const userContent = fillTemplateWith(content, modelConfig);
         console.log("[User Input] after template: ", userContent);
+
+        if (
+          config.generateTitle.selected === GENERATE_TITLE_OPTION.prompt &&
+          session.topic === DEFAULT_TOPIC
+        ) {
+          get().generateSessionTopicWithPrompt(userContent);
+        }
 
         const userMessage: ChatMessage = createMessage({
           role: "user",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -92,6 +92,7 @@ interface ChatStore {
   nextSession: (delta: number) => void;
   onNewMessage: (message: ChatMessage) => void;
   onUserInput: (content: string) => Promise<void>;
+  generateSessionTopicWithAI: () => void;
   summarizeSession: () => void;
   updateStat: (message: ChatMessage) => void;
   updateCurrentSession: (updater: (session: ChatSession) => void) => void;
@@ -478,7 +479,7 @@ export const useChatStore = create<ChatStore>()(
         });
       },
 
-      summarizeSession() {
+      generateSessionTopicWithAI() {
         const session = get().currentSession();
 
         // remove error messages if any
@@ -510,6 +511,15 @@ export const useChatStore = create<ChatStore>()(
             },
           });
         }
+      },
+
+      summarizeSession() {
+        const session = get().currentSession();
+
+        // remove error messages if any
+        const messages = session.messages;
+
+        get().generateSessionTopicWithAI();
 
         const modelConfig = session.mask.modelConfig;
         const summarizeIndex = Math.max(

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -152,7 +152,7 @@ export const useAppConfig = create<ChatConfigStore>()(
     }),
     {
       name: StoreKey.Config,
-      version: 3.6,
+      version: 3.7,
       migrate(persistedState, version) {
         const state = persistedState as ChatConfig;
 
@@ -173,6 +173,10 @@ export const useAppConfig = create<ChatConfigStore>()(
 
         if (version < 3.6) {
           state.modelConfig.enableInjectSystemPrompts = true;
+        }
+
+        if (version < 3.7) {
+          state.generateTitle.selected = GENERATE_TITLE_OPTION.ai;
         }
 
         return state as any;

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import { LLMModel } from "../client/api";
 import { getClientConfig } from "../config/client";
 import { DEFAULT_INPUT_TEMPLATE, DEFAULT_MODELS, StoreKey } from "../constant";
+import { GENERATE_TITLE_OPTION } from "../constant";
 
 export type ModelType = (typeof DEFAULT_MODELS)[number]["name"];
 
@@ -28,6 +29,10 @@ export const DEFAULT_CONFIG = {
   tightBorder: !!getClientConfig()?.isApp,
   sendPreviewBubble: true,
   sidebarWidth: 300,
+
+  generateTitle: {
+    selected: GENERATE_TITLE_OPTION.ai as GENERATE_TITLE_OPTION,
+  },
 
   disablePromptHint: false,
 


### PR DESCRIPTION
link #2613 

## 功能逻辑

只在当前标题为默认标题时执行相关逻辑。

### ai生成：

具体实现时，没有修改原来AI生成标题的逻辑，只是抽离到了单独的函数`generateSessionTopicWithAI`中。

修改了调用逻辑，不在`summarizeSession`中调用，改为在此函数被调用之前的`onNewMessage`函数中判断并调用。

### 用户prompt：

在`onUserInput`函数中处理根据用户输入确定标题的功能，顺序在发起llm请求之前，而非llm回复之后。

## UI

目前只有一个`ListItem`，但单独在一个`List`中，给后续细化此设置留下空间。

## 配置迁移

迁移为当前ai生成方案

## 选项支持多语言

但目前仅实现了cn和en