### PR TITLE
The mobile terminal ishitbottom does not perform -10

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -935,7 +935,7 @@ function _Chat() {
 
     const isTouchTopEdge = e.scrollTop <= edgeThreshold;
     const isTouchBottomEdge = bottomHeight >= e.scrollHeight - edgeThreshold;
-    const isHitBottom = bottomHeight >= e.scrollHeight - 10;
+    const isHitBottom = bottomHeight >= e.scrollHeight - (isMobileScreen ? 0 : 10);
 
     const prevPageMsgIndex = msgRenderIndex - CHAT_PAGE_SIZE;
     const nextPageMsgIndex = msgRenderIndex + CHAT_PAGE_SIZE;


### PR DESCRIPTION
移动端的触摸移动可以小到几像素，不应该有滚动范围，在触摸较低缓慢移动无法脱离自动滚动范围。
现在还是有低概率被强制滚动，怀疑是因为如果在文本高度变化下次检测前内移动依然会被滚动。