### PR TITLE
[+] Fix Export all data functionality to save state as a JSON file instead of overwriting it as a .txt file.

### DIFF
--- a/app/store/sync.ts
+++ b/app/store/sync.ts
@@ -31,7 +31,14 @@ export const useSyncStore = createPersistStore(
     export() {
       const state = getLocalAppState();
       const fileName = `Backup-${new Date().toLocaleString()}.json`;
-      downloadAs(JSON.stringify(state), fileName);
+      const json = JSON.stringify(state);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      link.click();
+      URL.revokeObjectURL(url);
       set({ lastSyncTime: Date.now() });
     },
 


### PR DESCRIPTION
The previous code provided a hook called `useSyncStore` that included an export function for exporting the state. However, the export functionality was overwriting the state as a .txt file (Tested in iPhone Browser : Safari), which was not desirable. To address this issue, the code was modified to export the state as a JSON file instead.

Before :
![376373485_331161802595019_3224349029097812344_n](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/48602426/8a29d17d-bca4-4d90-b3e4-e3bafeac4374)

After : 
![376371184_6651169288298657_8416188717840722477_n](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/48602426/81fe3bcd-2f20-4be4-a8bd-10d660572287)
