### PR TITLE
fix: Width changes abruptly when dragging the sidebar (jumps)

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -53,7 +53,7 @@ function useHotKey() {
 }
 
 function useDragSideBar() {
-  const limit = useCallback((x: number) => Math.min(MAX_SIDEBAR_WIDTH, x));
+  const limit = (x: number) => Math.min(MAX_SIDEBAR_WIDTH, x);
 
   const config = useAppConfig();
   const startX = useRef(0);

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -67,7 +67,13 @@ function useDragSideBar() {
     lastUpdateTime.current = Date.now();
     const d = e.clientX - startX.current;
     const nextWidth = limit(startDragWidth.current + d);
-    config.update((config) => (config.sidebarWidth = nextWidth));
+    config.update((config) => {
+      if (nextWidth < MIN_SIDEBAR_WIDTH) {
+        config.sidebarWidth = NARROW_SIDEBAR_WIDTH;
+      } else {
+        config.sidebarWidth = nextWidth;
+      }
+    });
   });
 
   const handleMouseUp = useRef(() => {
@@ -80,7 +86,7 @@ function useDragSideBar() {
   const onDragMouseDown = (e: MouseEvent) => {
     startX.current = e.clientX;
     // Remembers the initial width each time the mouse is pressed
-    startDragWidth.current = config.sidebarWidth
+    startDragWidth.current = config.sidebarWidth;
     window.addEventListener("mousemove", handleMouseMove.current);
     window.addEventListener("mouseup", handleMouseUp.current);
   };

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 
 import styles from "./home.module.scss";
 
@@ -53,7 +53,7 @@ function useHotKey() {
 }
 
 function useDragSideBar() {
-  const limit = (x: number) => Math.min(MAX_SIDEBAR_WIDTH, x);
+  const limit = useCallback((x: number) => Math.min(MAX_SIDEBAR_WIDTH, x));
 
   const config = useAppConfig();
   const startX = useRef(0);
@@ -71,14 +71,16 @@ function useDragSideBar() {
   });
 
   const handleMouseUp = useRef(() => {
-    startDragWidth.current = config.sidebarWidth ?? 300;
+    // In useRef the data is non-responsive, so `config.sidebarWidth` can't get the dynamic sidebarWidth
+    // startDragWidth.current = config.sidebarWidth ?? 300;
     window.removeEventListener("mousemove", handleMouseMove.current);
     window.removeEventListener("mouseup", handleMouseUp.current);
   });
 
   const onDragMouseDown = (e: MouseEvent) => {
     startX.current = e.clientX;
-
+    // Remembers the initial width each time the mouse is pressed
+    startDragWidth.current = config.sidebarWidth
     window.addEventListener("mousemove", handleMouseMove.current);
     window.addEventListener("mouseup", handleMouseUp.current);
   };


### PR DESCRIPTION
In useRef is non-responsive, we can't get the modified config.sidebarWidth dynamic modification value in handleMouseUp