### PR TITLE
Improving Text Direction

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -151,6 +151,7 @@ export function Markdown(
       ref={mdRef}
       onContextMenu={props.onContextMenu}
       onDoubleClickCapture={props.onDoubleClickCapture}
+      dir="auto"
     >
       {props.loading ? (
         <LoadingIcon />


### PR DESCRIPTION
Previously, dir="auto" only applied to paragraphs and did not affect other elements in Markdown, such as headers, lists, and tables. However, it now applies to all elements collectively as well as to individual paragraphs, by using dir="auto" in both places.

While ideally, applying dir="auto" to each individual Markdown element would be the optimal solution, as a non-developer, this is the best approach I could come up with using less code.

Also, I would love if you could add it to the input filed (where the messages are written). I am not sure how.