### PR TITLE
Encode google font url

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -115,7 +115,7 @@ const loadAsyncGoogleFont = () => {
     getClientConfig()?.buildMode === "export" ? remoteFontUrl : proxyFontUrl;
   linkEl.rel = "stylesheet";
   linkEl.href =
-    googleFontUrl + "/css2?family=Noto+Sans:wght@300;400;700;900&display=swap";
+    googleFontUrl + "/css2?family=" + encodeURIComponent("Noto Sans:wght@300;400;700;900") + "&display=swap";
   document.head.appendChild(linkEl);
 };
 


### PR DESCRIPTION
Fetching "Noto Sans" from Google Fonts returns a 400 error when deploying to Netlify. We should encode the `family` parameter like [Google Fonts](https://fonts.google.com/) website does.