### PR TITLE
Command Key (MetaKey) on MacOS as default

### DIFF
--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -1,4 +1,5 @@
 import { LLMModel } from "../client/api";
+import { isMacOS } from "../utils";
 import { getClientConfig } from "../config/client";
 import {
   DEFAULT_INPUT_TEMPLATE,
@@ -27,7 +28,7 @@ export enum Theme {
 export const DEFAULT_CONFIG = {
   lastUpdate: Date.now(), // timestamp, to merge state
 
-  submitKey: SubmitKey.CtrlEnter as SubmitKey,
+  submitKey: isMacOS() ? SubmitKey.MetaEnter : SubmitKey.CtrlEnter,
   avatar: "1f603",
   fontSize: 14,
   theme: Theme.Auto as Theme,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -173,3 +173,15 @@ export function autoGrowTextArea(dom: HTMLTextAreaElement) {
 export function getCSSVar(varName: string) {
   return getComputedStyle(document.body).getPropertyValue(varName).trim();
 }
+
+/**
+ * Detects if the Operation system is MacOS
+ */
+export function isMacOS(): boolean {
+    if (window !== 'undefined') {
+        let userAgent = window?.navigator?.userAgent
+        if (userAgent.indexOf('Mac') != -1) return true
+    }
+
+    return false
+}

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -178,10 +178,10 @@ export function getCSSVar(varName: string) {
  * Detects if the Operation system is MacOS
  */
 export function isMacOS(): boolean {
-    if (window !== 'undefined') {
-        let userAgent = window?.navigator?.userAgent
-        if (userAgent.indexOf('Mac') != -1) return true
-    }
+  if (typeof window !== "undefined") {
+    let userAgent = window?.navigator?.userAgent;
+    if (userAgent.indexOf("Mac") != -1) return true;
+  }
 
-    return false
+  return false;
 }

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -175,13 +175,13 @@ export function getCSSVar(varName: string) {
 }
 
 /**
- * Detects if the Operation system is MacOS
+ * Detects Macintosh
  */
 export function isMacOS(): boolean {
   if (typeof window !== "undefined") {
-    let userAgent = window?.navigator?.userAgent;
-    if (userAgent.indexOf("Mac") != -1) return true;
+    let userAgent = window.navigator.userAgent.toLocaleLowerCase();
+    const macintosh = /iphone|ipad|ipod|macintosh/.test(userAgent)
+    return !!macintosh
   }
-
-  return false;
+  return false
 }


### PR DESCRIPTION
I came across this project and I found it really amazing. but when I visited it and wrote a simple prompt and hit "CMD + ENTER" on MacOS, it didn't work. however with "CTR + ENTER" it worked. On MacOS it's really easy to press the "command" key instead of CTR.

I created a PR that fixes this issue, now the default key submitKey should be MetaKey on MacOS.

Hope it helps the project & community!


**DEMO**: https://nextgpteric.vercel.app/