### PR TITLE
UI Page [Auth Page]

### DIFF
--- a/app/components/auth.tsx
+++ b/app/components/auth.tsx
@@ -43,16 +43,20 @@ export function AuthPage() {
           access.updateCode(e.currentTarget.value);
         }}
       />
-      <div className={styles["auth-tips"]}>{Locale.Auth.SubTips}</div>
-      <input
-        className={styles["auth-input"]}
-        type="password"
-        placeholder={Locale.Settings.Token.Placeholder}
-        value={access.token}
-        onChange={(e) => {
-          access.updateToken(e.currentTarget.value);
-        }}
-      />
+      {!access.hideUserApiKey ? (
+        <>
+          <div className={styles["auth-tips"]}>{Locale.Auth.SubTips}</div>
+          <input
+            className={styles["auth-input"]}
+            type="password"
+            placeholder={Locale.Settings.Token.Placeholder}
+            value={access.token}
+            onChange={(e) => {
+              access.updateToken(e.currentTarget.value);
+            }}
+          />
+        </>
+      ) : null}
 
       <div className={styles["auth-actions"]}>
         <IconButton

--- a/app/components/auth.tsx
+++ b/app/components/auth.tsx
@@ -15,6 +15,7 @@ export function AuthPage() {
   const access = useAccessStore();
 
   const goHome = () => navigate(Path.Home);
+  const goChat = () => navigate(Path.Chat);
   const resetAccessCode = () => { access.updateCode(""); access.updateToken(""); }; // Reset access code to empty string
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export function AuthPage() {
         <IconButton
           text={Locale.Auth.Confirm}
           type="primary"
-          onClick={goHome}
+          onClick={goChat}
         />
         <IconButton
           text={Locale.Auth.Later}

--- a/app/components/auth.tsx
+++ b/app/components/auth.tsx
@@ -15,7 +15,7 @@ export function AuthPage() {
   const access = useAccessStore();
 
   const goHome = () => navigate(Path.Home);
-  const resetAccessCode = () => access.updateCode(""); // Reset access code to empty string
+  const resetAccessCode = () => { access.updateCode(""); access.updateToken(""); }; // Reset access code to empty string
 
   useEffect(() => {
     if (getClientConfig()?.isApp) {
@@ -42,6 +42,16 @@ export function AuthPage() {
           access.updateCode(e.currentTarget.value);
         }}
       />
+      <div className={styles["auth-tips"]}>{Locale.Auth.SubTips}</div>
+      <input
+        className={styles["auth-input"]}
+        type="password"
+        placeholder={Locale.Settings.Token.Placeholder}
+        value={access.token}
+        onChange={(e) => {
+          access.updateToken(e.currentTarget.value);
+        }}
+      />
 
       <div className={styles["auth-actions"]}>
         <IconButton
@@ -49,10 +59,13 @@ export function AuthPage() {
           type="primary"
           onClick={goHome}
         />
-        <IconButton text={Locale.Auth.Later} onClick={() => {
-          resetAccessCode();
-          goHome();
-        }} />
+        <IconButton
+          text={Locale.Auth.Later}
+          onClick={() => {
+            resetAccessCode();
+            goHome();
+          }}
+        />
       </div>
     </div>
   );

--- a/app/locales/ar.ts
+++ b/app/locales/ar.ts
@@ -10,6 +10,7 @@ const ar: PartialLocaleType = {
   Auth: {
     Title: "تحتاج إلى رمز الوصول",
     Tips: "يرجى إدخال رمز الوصول أدناه",
+    SubTips: "أو أدخل مفتاح واجهة برمجة تطبيقات OpenAI الخاص بك",
     Input: "رمز الوصول",
     Confirm: "تأكيد",
     Later: "لاحقًا",

--- a/app/locales/bn.ts
+++ b/app/locales/bn.ts
@@ -10,6 +10,7 @@ const bn: PartialLocaleType = {
   Auth: {
     Title: "একটি অ্যাক্সেস কোড প্রয়োজন",
     Tips: "নীচে অ্যাক্সেস কোড ইনপুট করুন",
+    SubTips: "অথবা আপনার OpenAI API কী প্রবেশ করুন",
     Input: "অ্যাক্সেস কোড",
     Confirm: "নিশ্চিত করুন",
     Later: "পরে",

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -13,6 +13,7 @@ const cn = {
   Auth: {
     Title: "需要密码",
     Tips: "管理员开启了密码验证，请在下方填入访问码",
+    SubTips: "或者输入你的 OpenAI API 密钥",
     Input: "在此处填写访问码",
     Confirm: "确认",
     Later: "稍后再说",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -15,6 +15,7 @@ const en: LocaleType = {
   Auth: {
     Title: "Need Access Code",
     Tips: "Please enter access code below",
+    SubTips: "Or enter your OpenAI API Key",
     Input: "access code",
     Confirm: "Confirm",
     Later: "Later",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -1,15 +1,11 @@
-import { getClientConfig } from "../config/client";
 import { SubmitKey } from "../store/config";
 import { PartialLocaleType } from "./index";
 
-const isApp = !!getClientConfig()?.isApp;
 const id: PartialLocaleType = {
   WIP: "Coming Soon...",
   Error: {
-    Unauthorized: isApp
-    ? "Kunci API tidak valid, silakan periksa di halaman [Pengaturan](/#/settings)."
-    : "Akses tidak diizinkan, silakan masukkan kode akses di halaman [autentikasi](/#/auth), atau masukkan kunci API OpenAI Anda.",
-  },
+    Unauthorized: "Akses tidak diizinkan, silakan masukkan kode akses atau masukkan kunci API OpenAI Anda. di halaman [autentikasi](/#/auth) atau di halaman [Pengaturan](/#/settings).",
+  },  
   Auth: {
     Title: "Diperlukan Kode Akses",
     Tips: "Masukkan kode akses di bawah",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -1,15 +1,19 @@
+import { getClientConfig } from "../config/client";
 import { SubmitKey } from "../store/config";
 import { PartialLocaleType } from "./index";
 
+const isApp = !!getClientConfig()?.isApp;
 const id: PartialLocaleType = {
   WIP: "Coming Soon...",
   Error: {
-    Unauthorized:
-      "Akses tidak diizinkan. Silakan [otorisasi](/#/auth) dengan memasukkan kode akses.",
+    Unauthorized: isApp
+    ? "Kunci API tidak valid, silakan periksa di halaman [Pengaturan](/#/settings)."
+    : "Akses tidak diizinkan, silakan masukkan kode akses di halaman [autentikasi](/#/auth), atau masukkan kunci API OpenAI Anda.",
   },
   Auth: {
     Title: "Diperlukan Kode Akses",
     Tips: "Masukkan kode akses di bawah",
+    SubTips: "Atau masukkan kunci API OpenAI Anda",
     Input: "Kode Akses",
     Confirm: "Konfirmasi",
     Later: "Nanti",


### PR DESCRIPTION
[+] feat(auth.tsx): add support for resetting access token in resetAccessCode function
[+] fix(auth.tsx): fix formatting issue in resetAccessCode function
[+] feat(locales): add support for sub tips in Auth component for multiple languages :
  - Add sub tips in Arabic locale (ar.ts)
  - Add sub tips in Bengali locale (bn.ts)
  - Add sub tips in Chinese locale (cn.ts)
  - Add sub tips in English locale (en.ts)
  - Add sub tips in Indonesian locale (id.ts)

Preview : 

![image](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/17626300/34c184fd-c1d7-42b7-aee2-4aa0750b76ef)
