### PR TITLE
UI Page Load & Save [Chat Commands]

### DIFF
--- a/app/command.ts
+++ b/app/command.ts
@@ -39,6 +39,8 @@ interface ChatCommands {
   prev?: Command;
   clear?: Command;
   del?: Command;
+  save?: Command;
+  load?: Command;
 }
 
 export const ChatCommandPrefix = ":";

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -53,6 +53,8 @@ import {
   selectOrCopy,
   autoGrowTextArea,
   useMobileScreen,
+  downloadAs,
+  readFromFile,
 } from "../utils";
 
 import dynamic from "next/dynamic";
@@ -651,6 +653,22 @@ function _Chat() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(measure, [userInput]);
 
+  const loadchat = () => {
+    readFromFile().then((content) => {
+      try {
+        const importedSession = JSON.parse(content);
+        chatStore.updateCurrentSession((session) => {
+          session.messages = importedSession.messages;
+          session.topic = importedSession.topic;
+          session.memoryPrompt = importedSession.memoryPrompt;
+          // Set any other properties you want to update in the session
+        });
+      } catch (error) {
+        console.error("Error importing chat session:", error);
+      }
+    });
+  };
+  
   // chat commands shortcuts
   const chatCommands = useChatCommand({
     new: () => chatStore.newSession(),
@@ -662,7 +680,10 @@ function _Chat() {
         (session) => (session.clearContextIndex = session.messages.length),
       ),
     del: () => chatStore.deleteSession(chatStore.currentSessionIndex),
-  });
+    save: () =>
+      downloadAs(JSON.stringify(session), `${session.topic}.json`),
+    load: loadchat,
+  });  
 
   // only search prompts when user input is short
   const SEARCH_TEXT_LIMIT = 30;

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -49,6 +49,8 @@ const cn = {
       prev: "上一个聊天",
       clear: "清除上下文",
       del: "删除聊天",
+      save: "保存当前会话聊天",
+      load: "加载会话聊天",
     },
     InputActions: {
       Stop: "停止响应",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -51,6 +51,8 @@ const en: LocaleType = {
       prev: "Previous Chat",
       clear: "Clear Context",
       del: "Delete Chat",
+      save: "Save a current session chat",
+      load: "Load a session chat",
     },
     InputActions: {
       Stop: "Stop",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -39,6 +39,8 @@ const id: PartialLocaleType = {
       prev: "Chat Sebelumnya",
       clear: "Bersihkan Percakapan",
       del: "Hapus Chat",
+      save: "Simpan Percakapan Sesi Saat Ini",
+      load: "Muat Percakapan Sesi",
     },
     InputActions: {
       Stop: "Berhenti",


### PR DESCRIPTION
Ref : [Feature] 我想每次对话的结果能够放到我的笔记本或者本地缓存， #2953
[+] feat(command.ts): add support for save and load commands in ChatCommands interface
[+] feat(chat.tsx): add functionality to loadchat function to load chat session from file
[+] feat(chat.tsx): add save and load commands to chatCommands object
[+] feat(cn.ts): add translations for save and load commands
[+] feat(en.ts): add translations for save and load commands
[+] feat(id.ts): add translations for save and load commands