### PR TITLE
UI Page [Chats]

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -27,6 +27,8 @@ import PinIcon from "../icons/pin.svg";
 import EditIcon from "../icons/rename.svg";
 import ConfirmIcon from "../icons/confirm.svg";
 import CancelIcon from "../icons/cancel.svg";
+import DownloadIcon from "../icons/download.svg";
+import UploadIcon from "../icons/upload.svg";
 
 import LightIcon from "../icons/light.svg";
 import DarkIcon from "../icons/dark.svg";
@@ -53,6 +55,8 @@ import {
   selectOrCopy,
   autoGrowTextArea,
   useMobileScreen,
+  downloadAs,
+  readFromFile,
 } from "../utils";
 
 import dynamic from "next/dynamic";
@@ -100,12 +104,50 @@ export function SessionConfigModel(props: { onClose: () => void }) {
   const maskStore = useMaskStore();
   const navigate = useNavigate();
 
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = async () => {
+    if (exporting) return;
+    setExporting(true);
+    await downloadAs(JSON.stringify(session), `${session.topic}.json`);
+    setExporting(false);
+  };
+
+  const importchat = () => {
+    readFromFile().then((content) => {
+      try {
+        const importedData = JSON.parse(content);
+        chatStore.updateCurrentSession((session) => {
+          Object.assign(session, importedData);
+        });
+      } catch (e) {
+        console.error("[Import] Failed to import JSON file:", e);
+        showToast(Locale.Settings.Sync.ImportFailed);
+      }
+    });
+  };
+
   return (
     <div className="modal-mask">
       <Modal
         title={Locale.Context.Edit}
         onClose={() => props.onClose()}
         actions={[
+          <IconButton
+          key="export"
+          icon={<DownloadIcon />}
+          bordered
+          text={Locale.UI.Export}
+          onClick={handleExport}
+          disabled={exporting}
+        />,
+        <IconButton
+          key="import"
+          icon={<UploadIcon />}
+          bordered
+          text={Locale.UI.Import}
+          onClick={importchat}
+        />,
           <IconButton
             key="reset"
             icon={<ResetIcon />}


### PR DESCRIPTION
- [+] feat(chat.tsx): add support for exporting and importing chat session data

Screenshot : 

![Screenshot_284](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/17626300/45b68044-6ec0-40c2-b757-0279ca32c67e)
