### PR TITLE
feat: enlarge max tokens for gpt4-turbo

### DIFF
--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -76,7 +76,7 @@ export function ModelConfigList(props: {
         <input
           type="number"
           min={100}
-          max={100000}
+          max={1000000}
           value={props.modelConfig.max_tokens}
           onChange={(e) =>
             props.updateConfig(


### PR DESCRIPTION
gpt-4-turbo token context is 128k. We should enlarge max tokens for it and the future.