### PR TITLE
[Fix] baseUrl is empty 

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -18,7 +18,7 @@ export async function requestOpenai(req: NextRequest) {
   );
 
   let baseUrl =
-    serverConfig.azureUrl ?? serverConfig.baseUrl ?? OPENAI_BASE_URL;
+    serverConfig.azureUrl || serverConfig.baseUrl || OPENAI_BASE_URL;
 
   if (!baseUrl.startsWith("http")) {
     baseUrl = `https://${baseUrl}`;


### PR DESCRIPTION
Issue
[Proxy]  v1/chat/completions?path=v1&path=chat&path=completions
[Base Url] https:/
[Org ID]
Fetch URL:  https://v1/chat/completions?path=v1&path=chat&path=completions
[OpenAI]   [TypeError: fetch failed] {
  cause:  [Error: getaddrinfo ENOTFOUND v1] {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'v1'
}
}