### PR TITLE
UI (model selection): hide unavailable model options

### DIFF
--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -25,11 +25,13 @@ export function ModelConfigList(props: {
             );
           }}
         >
-          {allModels.map((v, i) => (
-            <option value={v.name} key={i} disabled={!v.available}>
-              {v.name}
-            </option>
-          ))}
+          {allModels
+            .filter((v) => v.available)
+            .map((v, i) => (
+              <option value={v.name} key={i}>
+                {v.displayName}
+              </option>
+            ))}
         </Select>
       </ListItem>
       <ListItem


### PR DESCRIPTION
It seems hiding unavailable model gives better user experience than showing disabled, especially when using model rename feat and custom models supported by `CUSTOM_MODELS`.

For example, when using custom model, I will disable all build-in models and add a few custom models. I only want to see my custom models and select from them. Showing the disabled ones is not useful.

I came up this idea when trying to add Azure deployment selection feat https://github.com/nanaya-tachibana/ChatGPT-Next-Web/commit/24cabeb04888bc2d1585137af1c4634f67cb4a5a