### PR TITLE
feat (Azure): support Azure deployment selection

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -30,9 +30,7 @@ export async function requestOpenai(req: NextRequest) {
       const jsonBody = JSON.parse(clonedBody) as { model?: string };
 
       const model = modelTable[jsonBody?.model ?? ""];
-      if (azureUrl && model.available === true) {
-        azureUrl = makeAzureBaseUrl(azureUrl, model.name);
-      } else if (model.available === false) {
+      if (!azureUrl && model.available === false) {
         // not undefined and is false
         // #1815 try to refuse gpt4 request
         return NextResponse.json(
@@ -44,6 +42,10 @@ export async function requestOpenai(req: NextRequest) {
             status: 403,
           },
         );
+      } else if (azureUrl && model.available === true) {
+        // if there is an avaliable model, update the deployment id in the url.
+        // otherwise leave the url unchanged.
+        azureUrl = makeAzureBaseUrl(azureUrl, model.name);
       }
     } catch (e) {
       console.error("[OpenAI] gpt4 filter", e);

--- a/app/azure.ts
+++ b/app/azure.ts
@@ -7,3 +7,16 @@ export function makeAzurePath(path: string, apiVersion: string) {
 
   return path;
 }
+
+export function makeAzureBaseUrl(
+  url: string,
+  deploymentId: string | undefined,
+) {
+  const DEPLOYMENTS = "deployments";
+  if (!deploymentId || url.indexOf(DEPLOYMENTS) == -1) {
+    return url;
+  }
+
+  const end = url.indexOf(DEPLOYMENTS) + DEPLOYMENTS.length;
+  return url.substring(0, end) + "/" + deploymentId;
+}


### PR DESCRIPTION
I'd like to add the support of Azure deployment selection to give the same model switching experience when using Azure openAI service.

This patch probably won't break anything when `CUSTOM_MODELS` is not set.
User can use `-` to hide all internal models and use `+` to add azure deployments in `CUSTOM_MODELS`. 

- When there is a request for an available model, replace the deployment in the `AZURE_URL`. 
- When there is a request for an unavailable model, for example the [summary scenario](https://github.com/Yidadaa/ChatGPT-Next-Web/blob/9da455a7eabcf22c3cbdb8bfe0ec3203a869e4e9/app/store/chat.ts#L85), use the default deployment in the `AZURE_URL`.