### PR TITLE
config: exclude hkg1 from the deployment regions of the edge function

### DIFF
--- a/app/api/openai/[...path]/route.ts
+++ b/app/api/openai/[...path]/route.ts
@@ -75,3 +75,4 @@ export const GET = handle;
 export const POST = handle;
 
 export const runtime = "edge";
+export const preferredRegion = ['arn1', 'bom1', 'cdg1', 'cle1', 'cpt1', 'dub1', 'fra1', 'gru1', 'hnd1', 'iad1', 'icn1', 'kix1', 'lhr1', 'pdx1', 'sfo1', 'sin1', 'syd1'];


### PR DESCRIPTION
Currently, OpenAI has blocked the IP addresses of Vercel's Hong Kong servers, which has resulted in all users redirected to the HKG1 data center being unable to use OpenAI's services. Temporarily deploying the OpenAI route's edge function in regions other than HKG1 can provide a temporary solution to this issue.