### PR TITLE
Fix Model where fine-tuning model is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ If you want to disable parse settings from url, set this to 1.
 > Default: Empty
 > Example: `+llama,+claude-2,-gpt-3.5-turbo,gpt-4-1106-preview:gpt-4-turbo` means add `llama, claude-2` to model list, and remove `gpt-3.5-turbo` from list, and display `gpt-4-1106-preview` as `gpt-4-turbo`.
 
+> Example Fine-Tuning Model OpenAI: `ft:gpt-3.5-turbo-1106:github-developer-program::88ufxjNg|Fine-Tuning-1` display `ft:gpt-3.5-turbo-1106:github-developer-program::88ufxjNg` as `Fine-Tuning-1`.
+
 To control custom models, use `+` to add a custom model, use `-` to hide a model, use `name:displayName` to customize model name, separated by comma.
 
 ## Requirements

--- a/README_CN.md
+++ b/README_CN.md
@@ -124,6 +124,8 @@ Azure Api 版本，你可以在这里找到：[Azure 文档](https://learn.micro
 
 > 示例：`+qwen-7b-chat,+glm-6b,-gpt-3.5-turbo,gpt-4-1106-preview:gpt-4-turbo` 表示增加 `qwen-7b-chat` 和 `glm-6b` 到模型列表，而从列表中删除 `gpt-3.5-turbo`，并将 `gpt-4-1106-preview` 模型名字展示为 `gpt-4-turbo`。
 
+> OpenAI 微调模型示例：`ft:gpt-3.5-turbo-1106:github-developer-program::88ufxjNg|Fine-Tuning-1` 将 `ft:gpt-3.5-turbo-1106:github-developer-program::88ufxjNg` 显示为 `Fine-Tuning-1`。
+
 用来控制模型列表，使用 `+` 增加一个模型，使用 `-` 来隐藏一个模型，使用 `模型名:展示名` 来自定义模型的展示名，用英文逗号隔开。
 
 ## 开发

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -26,7 +26,7 @@ export function collectModelTable(
       const available = !m.startsWith("-");
       const nameConfig =
         m.startsWith("+") || m.startsWith("-") ? m.slice(1) : m;
-      const [name, displayName] = nameConfig.split(":");
+      const [name, displayName] = nameConfig.split(":") && nameConfig.split("|"); // `|` is aliases for fine-tuning model
       modelTable[name] = {
         name,
         displayName: displayName || name,


### PR DESCRIPTION
[+] fix(model.ts): fix splitting of nameConfig by adding `|` as an alternative delimiter

Issue : [Bug] 2.9.12 自定义模型添加微调模型失败 #3304
E.g Usage : `ft:gpt-3.5-turbo-0613:github-developer-program::88ufxjNg|Fine-Tunning`