### PR TITLE
Fix UI/UX Page Chats [Memory Prompt] [Stored Local Storage]

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -557,7 +557,10 @@ export const useChatStore = createPersistStore(
             },
             onFinish(message) {
               console.log("[Memory] ", message);
-              session.lastSummarizeIndex = lastSummarizeIndex;
+              get().updateCurrentSession((session) => {
+                session.lastSummarizeIndex = lastSummarizeIndex;
+                session.memoryPrompt = message; // Update the memory prompt for stored it in local storage
+              });
             },
             onError(err) {
               console.error("[Summarize] ", err);


### PR DESCRIPTION
- [+] fix(chat.ts): update the memory prompt in onFinish callback
- [+] feat(chat.ts): update the current session with lastSummarizeIndex and memoryPrompt

Issue known : [Bug] Memory Prompt not stored properly in top 1 of chat list https://github.com/Yidadaa/ChatGPT-Next-Web/issues/3368