### PR TITLE
use gpt-3.5-turbo-1106 to summarize

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -84,11 +84,11 @@ You are ChatGPT, a large language model trained by OpenAI.
 Knowledge cutoff: {{cutoff}}
 Current model: {{model}}
 Current time: {{time}}
-Latex inline: $x^2$ 
+Latex inline: $x^2$
 Latex block: $$e=mc^2$$
 `;
 
-export const SUMMARIZE_MODEL = "gpt-3.5-turbo";
+export const SUMMARIZE_MODEL = "gpt-3.5-turbo-1106";
 
 export const KnowledgeCutOffDate: Record<string, string> = {
   default: "2021-09",


### PR DESCRIPTION
use gpt-3.5-turbo-1106 to summarize is best way.
cheaper and larger context window.
no reason to refuse this update.