### PR TITLE
fix: allow isVisionModel function read runtime env var VISION_MODELS

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -13,6 +13,7 @@ const DANGER_CONFIG = {
   hideBalanceQuery: serverConfig.hideBalanceQuery,
   disableFastLink: serverConfig.disableFastLink,
   customModels: serverConfig.customModels,
+  visionModels: serverConfig.visionModels,
   defaultModel: serverConfig.defaultModel,
 };
 

--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -84,9 +84,12 @@ export class ClaudeApi implements LLMApi {
     return res?.content?.[0]?.text;
   }
   async chat(options: ChatOptions): Promise<void> {
-    const visionModel = isVisionModel(options.config.model);
-
     const accessStore = useAccessStore.getState();
+
+    const visionModel = isVisionModel(
+      options.config.model,
+      accessStore.visionModels,
+    );
 
     const shouldStream = !!options.config.stream;
 

--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -83,7 +83,7 @@ export class GeminiProApi implements LLMApi {
     }
     const messages = _messages.map((v) => {
       let parts: any[] = [{ text: getMessageTextContent(v) }];
-      if (isVisionModel(options.config.model)) {
+      if (isVisionModel(options.config.model, accessStore.visionModels)) {
         const images = getMessageImages(v);
         if (images.length > 0) {
           multimodal = true;

--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -83,7 +83,12 @@ export class GeminiProApi implements LLMApi {
     }
     const messages = _messages.map((v) => {
       let parts: any[] = [{ text: getMessageTextContent(v) }];
-      if (isVisionModel(options.config.model, accessStore.visionModels)) {
+      if (
+        isVisionModel(
+          options.config.model,
+          useAccessStore.getState().visionModels,
+        )
+      ) {
         const images = getMessageImages(v);
         if (images.length > 0) {
           multimodal = true;

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -194,6 +194,8 @@ export class ChatGPTApi implements LLMApi {
 
     let requestPayload: RequestPayload | DalleRequestPayload;
 
+    const accessStore = useAccessStore.getState();
+
     const isDalle3 = _isDalle3(options.config.model);
     const isO1 = options.config.model.startsWith("o1");
     if (isDalle3) {
@@ -211,7 +213,10 @@ export class ChatGPTApi implements LLMApi {
         style: options.config?.style ?? "vivid",
       };
     } else {
-      const visionModel = isVisionModel(options.config.model);
+      const visionModel = isVisionModel(
+        options.config.model,
+        accessStore.visionModels,
+      );
       const messages: ChatOptions["messages"] = [];
       for (const v of options.messages) {
         const content = visionModel

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -197,7 +197,7 @@ export class ChatGPTApi implements LLMApi {
     const accessStore = useAccessStore.getState();
 
     const isDalle3 = _isDalle3(options.config.model);
-    const isO1 = options.config.model.startsWith("o1");
+    const isOseries = options.config.model.match(/^o\d/) !== null;
     if (isDalle3) {
       const prompt = getMessageTextContent(
         options.messages.slice(-1)?.pop() as any,
@@ -222,7 +222,7 @@ export class ChatGPTApi implements LLMApi {
         const content = visionModel
           ? await preProcessImageContent(v.content)
           : getMessageTextContent(v);
-        if (!(isO1 && v.role === "system"))
+        if (!(isOseries && v.role === "system"))
           messages.push({ role: v.role, content });
       }
 
@@ -231,16 +231,16 @@ export class ChatGPTApi implements LLMApi {
         messages,
         stream: options.config.stream,
         model: modelConfig.model,
-        temperature: !isO1 ? modelConfig.temperature : 1,
-        presence_penalty: !isO1 ? modelConfig.presence_penalty : 0,
-        frequency_penalty: !isO1 ? modelConfig.frequency_penalty : 0,
-        top_p: !isO1 ? modelConfig.top_p : 1,
+        temperature: !isOseries ? modelConfig.temperature : 1,
+        presence_penalty: !isOseries ? modelConfig.presence_penalty : 0,
+        frequency_penalty: !isOseries ? modelConfig.frequency_penalty : 0,
+        top_p: !isOseries ? modelConfig.top_p : 1,
         // max_tokens: Math.max(modelConfig.max_tokens, 1024),
         // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
       };
 
       // O1 使用 max_completion_tokens 控制token数 (https://platform.openai.com/docs/guides/reasoning#controlling-costs)
-      if (isO1) {
+      if (isOseries) {
         requestPayload["max_completion_tokens"] = modelConfig.max_tokens;
       }
 
@@ -364,7 +364,7 @@ export class ChatGPTApi implements LLMApi {
         // make a fetch request
         const requestTimeoutId = setTimeout(
           () => controller.abort(),
-          isDalle3 || isO1 ? REQUEST_TIMEOUT_MS * 4 : REQUEST_TIMEOUT_MS, // dalle3 using b64_json is slow.
+          isDalle3 || isOseries ? REQUEST_TIMEOUT_MS * 4 : REQUEST_TIMEOUT_MS, // dalle3 using b64_json is slow.
         );
 
         const res = await fetch(chatPath, chatPayload);

--- a/app/client/platforms/tencent.ts
+++ b/app/client/platforms/tencent.ts
@@ -94,7 +94,11 @@ export class HunyuanApi implements LLMApi {
   }
 
   async chat(options: ChatOptions) {
-    const visionModel = isVisionModel(options.config.model);
+    const accessStore = useAccessStore.getState();
+    const visionModel = isVisionModel(
+      options.config.model,
+      accessStore.visionModels,
+    );
     const messages = options.messages.map((v, index) => ({
       // "Messages 中 system 角色必须位于列表的最开始"
       role: index !== 0 && v.role === "system" ? "user" : v.role,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -490,6 +490,7 @@ export function ChatActions(props: {
   const currentProviderName =
     session.mask.modelConfig?.providerName || ServiceProvider.OpenAI;
   const allModels = useAllModels();
+  const customVisionModels = useAccessStore().visionModels;
   const models = useMemo(() => {
     const filteredModels = allModels.filter((m) => m.available);
     const defaultModel = filteredModels.find((m) => m.isDefault);
@@ -529,7 +530,7 @@ export function ChatActions(props: {
   const isMobileScreen = useMobileScreen();
 
   useEffect(() => {
-    const show = isVisionModel(currentModel);
+    const show = isVisionModel(currentModel, customVisionModels);
     setShowUploadImage(show);
     if (!show) {
       props.setAttachImages([]);
@@ -1457,10 +1458,12 @@ function _Chat() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const customVisionModels = useAccessStore().visionModels;
+
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
       const currentModel = chatStore.currentSession().mask.modelConfig.model;
-      if (!isVisionModel(currentModel)) {
+      if (!isVisionModel(currentModel, customVisionModels)) {
         return;
       }
       const items = (event.clipboardData || window.clipboardData).items;
@@ -1497,7 +1500,7 @@ function _Chat() {
         }
       }
     },
-    [attachImages, chatStore],
+    [attachImages, chatStore, customVisionModels],
   );
 
   async function uploadImage() {
@@ -1545,7 +1548,7 @@ function _Chat() {
     setAttachImages(images);
   }
 
-  // 快捷键 shortcut keys
+  // 捷键 shortcut keys
   const [showShortcutKeyModal, setShowShortcutKeyModal] = useState(false);
 
   useEffect(() => {

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1436,6 +1436,12 @@ function _Chat() {
 
         if (payload.code) {
           accessStore.update((access) => (access.accessCode = payload.code!));
+          if (accessStore.isAuthorized()) {
+            context.pop();
+            const copiedHello = Object.assign({}, BOT_HELLO);
+            context.push(copiedHello);
+            setUserInput(" ");
+          }
         }
       } catch {
         console.error("[Command] failed to get settings from url: ", text);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1411,6 +1411,7 @@ function _Chat() {
         const payload = JSON.parse(text) as {
           key?: string;
           url?: string;
+          code?: string;
         };
 
         console.log("[Command] got settings from url: ", payload);
@@ -1431,6 +1432,10 @@ function _Chat() {
             }
             accessStore.update((access) => (access.useCustomConfig = true));
           });
+        }
+
+        if (payload.code) {
+          accessStore.update((access) => (access.accessCode = payload.code!));
         }
       } catch {
         console.error("[Command] failed to get settings from url: ", text);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1167,6 +1167,7 @@ function _Chat() {
 
   const onDelete = (msgId: string) => {
     deleteMessage(msgId);
+    syncStore.upload();
   };
 
   const onResend = (message: ChatMessage) => {

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -28,6 +28,7 @@ import { AuthPage } from "./auth";
 import { getClientConfig } from "../config/client";
 import { type ClientApi, getClientApi } from "../client/api";
 import { useAccessStore } from "../store";
+import { useSyncStore } from "../store/sync";
 import clsx from "clsx";
 
 export function Loading(props: { noLogo?: boolean }) {
@@ -238,6 +239,8 @@ export function Home() {
   if (!useHasHydrated()) {
     return <Loading />;
   }
+
+  useSyncStore.getState().download();
 
   return (
     <ErrorBoundary>

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -534,7 +534,22 @@ function SyncItems() {
                 text={Locale.UI.Overwrite}
                 onClick={async () => {
                   try {
-                    await syncStore.overwrite();
+                    await syncStore.upload();
+                    showToast(Locale.Settings.Sync.Success);
+                  } catch (e) {
+                    showToast(Locale.Settings.Sync.Fail);
+                    console.error("[Sync]", e);
+                  }
+                }}
+              />
+            )}
+            {couldSync && (
+              <IconButton
+                icon={<DownloadIcon />}
+                text={Locale.UI.Overwrite}
+                onClick={async () => {
+                  try {
+                    await syncStore.download();
                     showToast(Locale.Settings.Sync.Success);
                   } catch (e) {
                     showToast(Locale.Settings.Sync.Fail);
@@ -1408,7 +1423,10 @@ export function Settings() {
             <IconButton
               aria={Locale.UI.Close}
               icon={<CloseIcon />}
-              onClick={() => navigate(Path.Home)}
+              onClick={() => {
+                navigate(Path.Home);
+                useSyncStore.getState().sync();
+              }}
               bordered
             />
           </div>

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -530,6 +530,21 @@ function SyncItems() {
             />
             {couldSync && (
               <IconButton
+                icon={<UploadIcon />}
+                text={Locale.UI.Overwrite}
+                onClick={async () => {
+                  try {
+                    await syncStore.overwrite();
+                    showToast(Locale.Settings.Sync.Success);
+                  } catch (e) {
+                    showToast(Locale.Settings.Sync.Fail);
+                    console.error("[Sync]", e);
+                  }
+                }}
+              />
+            )}
+            {couldSync && (
+              <IconButton
                 icon={<ResetIcon />}
                 text={Locale.UI.Sync}
                 onClick={async () => {

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -21,6 +21,7 @@ declare global {
       ENABLE_BALANCE_QUERY?: string; // allow user to query balance or not
       DISABLE_FAST_LINK?: string; // disallow parse settings from url or not
       CUSTOM_MODELS?: string; // to control custom models
+      VISION_MODELS?: string; // to control vision models
       DEFAULT_MODEL?: string; // to control default model in every new chat window
 
       // stability only
@@ -123,13 +124,16 @@ export const getServerSideConfig = () => {
 
   const disableGPT4 = !!process.env.DISABLE_GPT4;
   let customModels = process.env.CUSTOM_MODELS ?? "";
+  let visionModels = process.env.VISION_MODELS ?? "";
   let defaultModel = process.env.DEFAULT_MODEL ?? "";
 
   if (disableGPT4) {
     if (customModels) customModels += ",";
     customModels += DEFAULT_MODELS.filter(
       (m) =>
-        (m.name.startsWith("gpt-4") || m.name.startsWith("chatgpt-4o") || m.name.startsWith("o1")) &&
+        (m.name.startsWith("gpt-4") ||
+          m.name.startsWith("chatgpt-4o") ||
+          m.name.startsWith("o1")) &&
         !m.name.startsWith("gpt-4o-mini"),
     )
       .map((m) => "-" + m.name)
@@ -247,6 +251,7 @@ export const getServerSideConfig = () => {
     hideBalanceQuery: !process.env.ENABLE_BALANCE_QUERY,
     disableFastLink: !!process.env.DISABLE_FAST_LINK,
     customModels,
+    visionModels,
     defaultModel,
     allowedWebDavEndpoints,
   };

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -757,6 +757,7 @@ const cn = {
     Export: "导出",
     Import: "导入",
     Sync: "同步",
+    Overwrite: "覆盖",
     Config: "配置",
   },
   Exporter: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -762,6 +762,7 @@ const en: LocaleType = {
     Edit: "Edit",
     Export: "Export",
     Import: "Import",
+    Overwrite: "Overwrite",
     Sync: "Sync",
     Config: "Config",
   },

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -589,6 +589,7 @@ const fr: PartialLocaleType = {
     Edit: "Modifier",
     Export: "Exporter",
     Import: "Importer",
+    Overwrite: "Remplacer",
     Sync: "Synchroniser",
     Config: "Configurer",
   },

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -590,6 +590,7 @@ const it: PartialLocaleType = {
     Edit: "Modifica",
     Export: "Esporta",
     Import: "Importa",
+    Overwrite: "Sostituisci",
     Sync: "Sincronizza",
     Config: "Configura",
   },

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -505,6 +505,7 @@ const pt: PartialLocaleType = {
     Edit: "Editar",
     Export: "Exportar",
     Import: "Importar",
+    Overwrite: "Substituir",
     Sync: "Sincronizar",
     Config: "Configurar",
   },

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -123,6 +123,7 @@ const DEFAULT_ACCESS_STATE = {
   disableGPT4: false,
   disableFastLink: false,
   customModels: "",
+  visionModels: "",
   defaultModel: "",
 
   // tts config

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -29,6 +29,7 @@ import { ModelConfig, ModelType, useAppConfig } from "./config";
 import { useAccessStore } from "./access";
 import { collectModelsWithDefaultModel } from "../utils/model";
 import { createEmptyMask, Mask } from "./mask";
+import { useSyncStore } from "./sync";
 
 const localStorage = safeLocalStorage();
 
@@ -226,6 +227,8 @@ export const useChatStore = createPersistStore(
           currentSessionIndex: 0,
           sessions: [newSession, ...state.sessions],
         }));
+
+        useSyncStore.getState().upload();
       },
 
       clearSessions() {
@@ -233,6 +236,8 @@ export const useChatStore = createPersistStore(
           sessions: [createEmptySession()],
           currentSessionIndex: 0,
         }));
+
+        useSyncStore.getState().upload();
       },
 
       selectSession(index: number) {
@@ -264,6 +269,8 @@ export const useChatStore = createPersistStore(
             sessions: newSessions,
           };
         });
+
+        useSyncStore.getState().upload();
       },
 
       newSession(mask?: Mask) {
@@ -326,6 +333,8 @@ export const useChatStore = createPersistStore(
           currentSessionIndex: nextIndex,
           sessions,
         }));
+
+        useSyncStore.getState().upload();
 
         showToast(
           Locale.Home.DeleteToast,
@@ -433,6 +442,8 @@ export const useChatStore = createPersistStore(
               get().onNewMessage(botMessage, session);
             }
             ChatControllerPool.remove(session.id, botMessage.id);
+
+            useSyncStore.getState().upload();
           },
           onBeforeTool(tool: ChatMessageTool) {
             (botMessage.tools = botMessage?.tools || []).push(tool);
@@ -727,8 +738,10 @@ export const useChatStore = createPersistStore(
                 console.log("[Memory] ", message);
                 get().updateTargetSession(session, (session) => {
                   session.lastSummarizeIndex = lastSummarizeIndex;
-                  session.memoryPrompt = message; // Update the memory prompt for stored it in local storage
+                  session.memoryPrompt = message;
                 });
+
+                useSyncStore.getState().upload();
               }
             },
             onError(err) {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -4,7 +4,6 @@ import { getClientConfig } from "../config/client";
 import {
   DEFAULT_INPUT_TEMPLATE,
   DEFAULT_MODELS,
-  DEFAULT_SIDEBAR_WIDTH,
   DEFAULT_TTS_ENGINE,
   DEFAULT_TTS_ENGINES,
   DEFAULT_TTS_MODEL,
@@ -46,18 +45,20 @@ export const DEFAULT_CONFIG = {
   fontSize: 14,
   fontFamily: "",
   theme: Theme.Auto as Theme,
-  tightBorder: !!config?.isApp,
-  sendPreviewBubble: true,
+  // tightBorder: !!config?.isApp,
+  tightBorder: true,
+  sendPreviewBubble: false,
   enableAutoGenerateTitle: true,
-  sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+  // sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+  sidebarWidth: 100,
 
   enableArtifacts: true, // show artifacts config
 
   enableCodeFold: true, // code fold config
 
-  disablePromptHint: false,
+  disablePromptHint: true,
 
-  dontShowMaskSplashScreen: false, // dont show splash screen when create chat
+  dontShowMaskSplashScreen: true, // dont show splash screen when create chat
   hideBuiltinMasks: false, // dont add builtin masks
 
   customModels: "",
@@ -68,12 +69,12 @@ export const DEFAULT_CONFIG = {
     providerName: "OpenAI" as ServiceProvider,
     temperature: 0.5,
     top_p: 1,
-    max_tokens: 4000,
+    max_tokens: 8000,
     presence_penalty: 0,
     frequency_penalty: 0,
     sendMemory: true,
-    historyMessageCount: 4,
-    compressMessageLengthThreshold: 1000,
+    historyMessageCount: 16,
+    compressMessageLengthThreshold: 1000000,
     compressModel: "",
     compressProviderName: "",
     enableInjectSystemPrompts: true,

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -7,6 +7,7 @@ import { ServiceProvider } from "./constant";
 import { fetch as tauriStreamFetch } from "./utils/stream";
 import { VISION_MODEL_REGEXES, EXCLUDE_VISION_MODEL_REGEXES } from "./constant";
 import { getClientConfig } from "./config/client";
+import { getModelProvider } from "./utils/model";
 
 export function trimTopic(topic: string) {
   // Fix an issue where double quotes still show in the Indonesian language
@@ -253,12 +254,15 @@ export function getMessageImages(message: RequestMessage): string[] {
   return urls;
 }
 
-export function isVisionModel(model: string) {
+export function isVisionModel(model: string, customVisionModels: string) {
   const clientConfig = getClientConfig();
-  const envVisionModels = clientConfig?.visionModels
-    ?.split(",")
-    .map((m) => m.trim());
-  if (envVisionModels?.includes(model)) {
+  const allVisionModelsList = [customVisionModels, clientConfig?.visionModels]
+    ?.join(",")
+    .split(",")
+    .map((m) => m.trim())
+    .filter(Boolean)
+    .map((m) => getModelProvider(m)[0]);
+  if (allVisionModelsList?.includes(model)) {
     return true;
   }
   return (

--- a/app/utils/sync.ts
+++ b/app/utils/sync.ts
@@ -1,11 +1,11 @@
 import {
   ChatSession,
-  useAccessStore,
-  useAppConfig,
+  // useAccessStore,
+  // useAppConfig,
   useChatStore,
 } from "../store";
-import { useMaskStore } from "../store/mask";
-import { usePromptStore } from "../store/prompt";
+// import { useMaskStore } from "../store/mask";
+// import { usePromptStore } from "../store/prompt";
 import { StoreKey } from "../constant";
 import { merge } from "./merge";
 
@@ -32,18 +32,18 @@ export type GetStoreState<T> = T extends { getState: () => infer U }
 
 const LocalStateSetters = {
   [StoreKey.Chat]: useChatStore.setState,
-  [StoreKey.Access]: useAccessStore.setState,
-  [StoreKey.Config]: useAppConfig.setState,
-  [StoreKey.Mask]: useMaskStore.setState,
-  [StoreKey.Prompt]: usePromptStore.setState,
+  // [StoreKey.Access]: useAccessStore.setState,
+  // [StoreKey.Config]: useAppConfig.setState,
+  // [StoreKey.Mask]: useMaskStore.setState,
+  // [StoreKey.Prompt]: usePromptStore.setState,
 } as const;
 
 const LocalStateGetters = {
   [StoreKey.Chat]: () => getNonFunctionFileds(useChatStore.getState()),
-  [StoreKey.Access]: () => getNonFunctionFileds(useAccessStore.getState()),
-  [StoreKey.Config]: () => getNonFunctionFileds(useAppConfig.getState()),
-  [StoreKey.Mask]: () => getNonFunctionFileds(useMaskStore.getState()),
-  [StoreKey.Prompt]: () => getNonFunctionFileds(usePromptStore.getState()),
+  // [StoreKey.Access]: () => getNonFunctionFileds(useAccessStore.getState()),
+  // [StoreKey.Config]: () => getNonFunctionFileds(useAppConfig.getState()),
+  // [StoreKey.Mask]: () => getNonFunctionFileds(useMaskStore.getState()),
+  // [StoreKey.Prompt]: () => getNonFunctionFileds(usePromptStore.getState()),
 } as const;
 
 export type AppState = {
@@ -100,22 +100,22 @@ const MergeStates: StateMerger = {
 
     return localState;
   },
-  [StoreKey.Prompt]: (localState, remoteState) => {
-    localState.prompts = {
-      ...remoteState.prompts,
-      ...localState.prompts,
-    };
-    return localState;
-  },
-  [StoreKey.Mask]: (localState, remoteState) => {
-    localState.masks = {
-      ...remoteState.masks,
-      ...localState.masks,
-    };
-    return localState;
-  },
-  [StoreKey.Config]: mergeWithUpdate<AppState[StoreKey.Config]>,
-  [StoreKey.Access]: mergeWithUpdate<AppState[StoreKey.Access]>,
+  // [StoreKey.Prompt]: (localState, remoteState) => {
+  //   localState.prompts = {
+  //     ...remoteState.prompts,
+  //     ...localState.prompts,
+  //   };
+  //   return localState;
+  // },
+  // [StoreKey.Mask]: (localState, remoteState) => {
+  //   localState.masks = {
+  //     ...remoteState.masks,
+  //     ...localState.masks,
+  //   };
+  //   return localState;
+  // },
+  // [StoreKey.Config]: mergeWithUpdate<AppState[StoreKey.Config]>,
+  // [StoreKey.Access]: mergeWithUpdate<AppState[StoreKey.Access]>,
 };
 
 export function getLocalAppState() {

--- a/nextchat.json
+++ b/nextchat.json
@@ -1,0 +1,16 @@
+{
+    "name": "nextchat",
+    "cwd": "/www/nextchat",
+    "script": "server.js",
+    "env": {
+        "PORT": 8032,
+        "CODE": "scut",
+        "BASE_URL": "https://oneapi.jyj.cx",
+        "OPENAI_API_KEY": "sk-jiangyj",
+        "HIDE_USER_API_KEY": true,
+        "CUSTOM_MODELS": "-all,gemini-2.0-pro-exp-02-05@openai,gemini-2.0-flash-thinking-exp-01-21@openai,gemini-2.0-flash-exp@openai,gemini-2.0-flash@openai,gemini-2.0-flash-lite@openai,gpt-4o-2024-11-20@openai,o3-mini@openai,deepseek-ai/deepseek-v3@openai,deepseek-ai/deepseek-r1@openai,deepseek-chat@openai,deepseek-reasoner@openai,ep-20250124104315-zsg4p@openai",
+        "DEFAULT_MODEL": "gemini-2.0-pro-exp-02-05@openai",
+        "WHITE_WEBDAV_ENDPOINTS": "https://dav.jyj.cx",
+        "VISION_MODELS": "gemini-2.0-flash-thinking-exp-01-21@openai,gemini-2.0-pro-exp-02-05@openai,gemini-2.0-flash-exp@openai,gemini-2.0-flash@openai,gemini-2.0-flash-lite@openai,gpt-4o-2024-11-20@openai,o3-mini@openai,deepseek-ai/DeepSeek-V3@openai,deepseek-ai/DeepSeek-R1@openai,deepseek-chat@openai,deepseek-reasoner@openai,ep-20250124104315-zsg4p@openai"
+    }
+}

--- a/test/vision-model-checker.test.ts
+++ b/test/vision-model-checker.test.ts
@@ -2,6 +2,7 @@ import { isVisionModel } from "../app/utils";
 
 describe("isVisionModel", () => {
   const originalEnv = process.env;
+  const customVisionModels = "custom-vlm,another-vlm";
 
   beforeEach(() => {
     jest.resetModules();
@@ -27,12 +28,12 @@ describe("isVisionModel", () => {
     ];
 
     visionModels.forEach((model) => {
-      expect(isVisionModel(model)).toBe(true);
+      expect(isVisionModel(model, customVisionModels)).toBe(true);
     });
   });
 
   test("should exclude specific models", () => {
-    expect(isVisionModel("claude-3-5-haiku-20241022")).toBe(false);
+    expect(isVisionModel("claude-3-5-haiku-20241022", customVisionModels)).toBe(false);
   });
 
   test("should not identify non-vision models", () => {
@@ -44,24 +45,26 @@ describe("isVisionModel", () => {
     ];
 
     nonVisionModels.forEach((model) => {
-      expect(isVisionModel(model)).toBe(false);
+      expect(isVisionModel(model, customVisionModels)).toBe(false);
     });
   });
 
   test("should identify models from VISION_MODELS env var", () => {
     process.env.VISION_MODELS = "custom-vision-model,another-vision-model";
-    
-    expect(isVisionModel("custom-vision-model")).toBe(true);
-    expect(isVisionModel("another-vision-model")).toBe(true);
-    expect(isVisionModel("unrelated-model")).toBe(false);
+
+    expect(isVisionModel("custom-vision-model", customVisionModels)).toBe(true);
+    expect(isVisionModel("another-vision-model", customVisionModels)).toBe(true);
+    expect(isVisionModel("custom-vlm", customVisionModels)).toBe(true);
+    expect(isVisionModel("another-vlm", customVisionModels)).toBe(true);
+    expect(isVisionModel("unrelated-model", customVisionModels)).toBe(false);
   });
 
   test("should handle empty or missing VISION_MODELS", () => {
     process.env.VISION_MODELS = "";
-    expect(isVisionModel("unrelated-model")).toBe(false);
+    expect(isVisionModel("unrelated-model", customVisionModels)).toBe(false);
 
     delete process.env.VISION_MODELS;
-    expect(isVisionModel("unrelated-model")).toBe(false);
-    expect(isVisionModel("gpt-4-vision")).toBe(true);
+    expect(isVisionModel("unrelated-model", customVisionModels)).toBe(false);
+    expect(isVisionModel("gpt-4-vision", customVisionModels)).toBe(true);
   });
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

**Problem:** Before the fix, the `isVisionModel` function read `VISION_MODELS` from the `getClientConfig` function. However, `getClientConfig` was unable to read `VISION_MODELS` from the program's runtime environment variables. This issue caused visual models outside the predefined and build-time environment variables to be evaluated as `false` by the `isVisionModel` function, resulting in them losing their visual capabilities. Specifically, the `VISION_MODELS` environment variable passed by users in Docker was not taking effect.

**Fix Logic:** The `VISION_MODELS` variable was added to `ProcessEnv` in `app/config/server.ts`. This allows the client to read it via `/api/config` and store it in `accessStore` along with other variables like `customModels`. Since the `isVisionModel` function in `app/utils.ts` cannot directly access `accessStore`, a new parameter, `customVisionModels`, was added to the `isVisionModel` function. When calling `isVisionModel`, `accessStore.visionModels` is passed to the `isVisionModel` function via the new `customVisionModels` parameter. This enables the `isVisionModel` function to read the `VISION_MODELS` runtime environment variable.

**Fix Result:** After the fix, the `isVisionModel` function can read `VISION_MODELS` not only from `getClientConfig` but also from the program's runtime environment variables, resolving the problem described above.

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

#### 📝 补充信息 | Additional Information

The test unit `test/vision-model-checker.test.ts` was adjusted. Custom visual models were passed in through the new `customVisionModels` parameter, and the tests passed.

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property for vision models in the configuration options.
	- Enhanced logic to determine vision models across various API classes.
	- Added support for custom vision models in the chat component and related functionalities.
	- Added a new optional environment variable for configuring vision models.
	- Introduced an overwrite feature for data synchronization.
	- Added a new JSON configuration file for the "nextchat" application.
	- Integrated upload and download actions into data synchronization with user feedback.
	- Enabled automatic synchronization triggers on chat session updates and navigation.
	- Added automatic data download on home component load.

- **Bug Fixes**
	- Improved handling of image uploads and pastes based on model type.

- **Documentation**
	- Expanded localization options for the "Overwrite" action in multiple languages.

- **Tests**
	- Enhanced test cases to include custom vision models in the identification logic.

- **Configuration Changes**
	- Updated default configuration values affecting UI elements and model parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->