### PR TITLE
use i18n for theme setting

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1533,7 +1533,7 @@ export function Settings() {
             >
               {Object.values(Theme).map((v) => (
                 <option value={v} key={v}>
-                  {v}
+                  {Locale.Settings.ThemeOptions[v]}
                 </option>
               ))}
             </Select>

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -211,6 +211,11 @@ const cn = {
     },
     SendKey: "发送键",
     Theme: "主题",
+    ThemeOptions: {
+      auto: "自动",
+      light: "亮色",
+      dark: "深色",
+    },
     TightBorder: "无边框模式",
     SendPreviewBubble: {
       Title: "预览气泡",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -213,6 +213,11 @@ const en: LocaleType = {
     },
     SendKey: "Send Key",
     Theme: "Theme",
+    ThemeOptions: {
+      auto: "Auto",
+      light: "Light",
+      dark: "Dark",
+    },
     TightBorder: "Tight Border",
     SendPreviewBubble: {
       Title: "Send Preview Bubble",

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -166,7 +166,7 @@ const tw = {
       },
     },
     Lang: {
-      Name: "Language", // ATTENTION: if you wanna add a new translation, please do not translate this value, leave it as `Language`
+      Name: "Language", // 注意：如果您想添加新的翻譯，請不要翻譯此值，保持為 Language
       All: "所有語言",
     },
     Avatar: "大頭貼",
@@ -198,6 +198,11 @@ const tw = {
     },
     SendKey: "傳送鍵",
     Theme: "主題",
+    ThemeOptions: {
+      auto: "自動",
+      light: "亮色",
+      dark: "深色",
+    },
     TightBorder: "緊湊邊框",
     SendPreviewBubble: {
       Title: "預覽氣泡",


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change
Use i18n for theme setting, including en, cn and tw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized theme options for settings in multiple languages (Chinese, English, Traditional Chinese)
  - Enhanced theme selection dropdown with user-friendly display names

- **Documentation**
  - Updated comments in Traditional Chinese locale file for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->