### PR TITLE
Migrate to claude 4

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -571,6 +571,8 @@ const anthropicModels = [
   "claude-3-5-sonnet-latest",
   "claude-3-7-sonnet-20250219",
   "claude-3-7-sonnet-latest",
+  "claude-sonnet-4-20250514",
+  "claude-opus-4-20250514",
 ];
 
 const baiduModels = [


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

Add support to claude 4 model. In the migration guide [[1](https://docs.anthropic.com/en/docs/about-claude/models/migrating-to-claude-4),[2](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals)], handling stop_reason is required. Therefore, an addition change 

```javascript
          if (chunkJson?.delta?.stop_reason === "refusal") {
            // Return a message to display to the user
            const refusalMessage = "\n\n[Assistant refused to respond. Please modify your request and try again.]";
            options.onError?.(new Error("Content policy violation: " + refusalMessage));
            return refusalMessage;
          }
```
is added in `app/clients/platforms/anthropics.ts` to give refusal message when we detected the stop_reason.


#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new models: Claude Sonnet 4 (20250514) and Claude Opus 4 (20250514).

* **Bug Fixes**
  * Improved handling of assistant refusal responses by displaying a content policy violation message to the user when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->