### PR TITLE
hotfix: Cloud data sync upstash support for Tauri desktop app 

### DIFF
--- a/app/utils/cloud/upstash.ts
+++ b/app/utils/cloud/upstash.ts
@@ -5,6 +5,62 @@ import { chunks } from "../format";
 export type UpstashConfig = SyncStore["upstash"];
 export type UpStashClient = ReturnType<typeof createUpstashClient>;
 
+async function httpFetch(
+  url: string,
+  options?: RequestInit,
+): Promise<Response> {
+  if (window.__TAURI__) {
+    // 转换 RequestInit 格式为 Tauri 期望的格式
+    const method = options?.method || "GET";
+    const headers: Record<string, string> = {};
+
+    // 处理 headers
+    if (options?.headers) {
+      if (options.headers instanceof Headers) {
+        options.headers.forEach((value, key) => {
+          headers[key] = value;
+        });
+      } else if (Array.isArray(options.headers)) {
+        options.headers.forEach(([key, value]) => {
+          headers[key] = value;
+        });
+      } else {
+        Object.assign(headers, options.headers);
+      }
+    }
+
+    // 处理 body
+    let body: number[] = [];
+    if (options?.body) {
+      if (typeof options.body === "string") {
+        body = Array.from(new TextEncoder().encode(options.body));
+      } else if (options.body instanceof ArrayBuffer) {
+        body = Array.from(new Uint8Array(options.body));
+      } else if (options.body instanceof Uint8Array) {
+        body = Array.from(options.body);
+      } else {
+        // 其他类型转换为字符串
+        body = Array.from(new TextEncoder().encode(String(options.body)));
+      }
+    }
+
+    const response = await window.__TAURI__.invoke("http_fetch", {
+      method,
+      url,
+      headers,
+      body,
+    });
+
+    // 将 Tauri 响应转换为 Response 对象格式
+    return new Response(new Uint8Array(response.body), {
+      status: response.status,
+      statusText: response.status_text,
+      headers: new Headers(response.headers),
+    });
+  }
+  return fetch(url, options);
+}
+
 export function createUpstashClient(store: SyncStore) {
   const config = store.upstash;
   const storeKey = config.username.length === 0 ? STORAGE_KEY : config.username;
@@ -17,7 +73,7 @@ export function createUpstashClient(store: SyncStore) {
   return {
     async check() {
       try {
-        const res = await fetch(this.path(`get/${storeKey}`, proxyUrl), {
+        const res = await httpFetch(this.path(`get/${storeKey}`, proxyUrl), {
           method: "GET",
           headers: this.headers(),
         });
@@ -30,7 +86,7 @@ export function createUpstashClient(store: SyncStore) {
     },
 
     async redisGet(key: string) {
-      const res = await fetch(this.path(`get/${key}`, proxyUrl), {
+      const res = await httpFetch(this.path(`get/${key}`, proxyUrl), {
         method: "GET",
         headers: this.headers(),
       });
@@ -42,7 +98,7 @@ export function createUpstashClient(store: SyncStore) {
     },
 
     async redisSet(key: string, value: string) {
-      const res = await fetch(this.path(`set/${key}`, proxyUrl), {
+      const res = await httpFetch(this.path(`set/${key}`, proxyUrl), {
         method: "POST",
         headers: this.headers(),
         body: value,
@@ -81,6 +137,9 @@ export function createUpstashClient(store: SyncStore) {
       };
     },
     path(path: string, proxyUrl: string = "") {
+      if (window.__TAURI__) {
+        return config.endpoint + "/" + path;
+      }
       if (!path.endsWith("/")) {
         path += "/";
       }
@@ -96,7 +155,7 @@ export function createUpstashClient(store: SyncStore) {
       const pathPrefix = "/api/upstash/";
 
       try {
-        let u = new URL(proxyUrl + pathPrefix + path);
+        let u = new URL(proxyUrl + pathPrefix + path, window.location.origin);
         // add query params
         u.searchParams.append("endpoint", config.endpoint);
         url = u.toString();

--- a/src-tauri/src/fetch.rs
+++ b/src-tauri/src/fetch.rs
@@ -1,0 +1,177 @@
+//
+// 普通 HTTP 请求处理模块
+//
+
+use std::time::Duration;
+use std::error::Error;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::collections::HashMap;
+use reqwest::Client;
+use reqwest::header::{HeaderName, HeaderMap};
+
+static REQUEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FetchResponse {
+  request_id: u32,
+  status: u16,
+  status_text: String,
+  headers: HashMap<String, String>,
+  body: Vec<u8>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ErrorResponse {
+  request_id: u32,
+  status: u16,
+  status_text: String,
+  error: String,
+}
+
+#[tauri::command]
+pub async fn http_fetch(
+  method: String,
+  url: String,
+  headers: HashMap<String, String>,
+  body: Vec<u8>,
+) -> Result<FetchResponse, String> {
+  
+  let request_id = REQUEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+  let mut _headers = HeaderMap::new();
+  for (key, value) in &headers {
+    match key.parse::<HeaderName>() {
+      Ok(header_name) => {
+        match value.parse() {
+          Ok(header_value) => {
+            _headers.insert(header_name, header_value);
+          }
+          Err(err) => {
+            return Err(format!("failed to parse header value '{}': {}", value, err));
+          }
+        }
+      }
+      Err(err) => {
+        return Err(format!("failed to parse header name '{}': {}", key, err));
+      }
+    }
+  }
+
+  // 解析 HTTP 方法
+  let method = method.parse::<reqwest::Method>()
+    .map_err(|err| format!("failed to parse method: {}", err))?;
+
+  // 创建客户端
+  let client = Client::builder()
+    .default_headers(_headers)
+    .redirect(reqwest::redirect::Policy::limited(3))
+    .connect_timeout(Duration::new(10, 0))
+    .timeout(Duration::new(30, 0))
+    .build()
+    .map_err(|err| format!("failed to create client: {}", err))?;
+
+  // 构建请求
+  let mut request = client.request(
+    method.clone(),
+    url.parse::<reqwest::Url>()
+      .map_err(|err| format!("failed to parse url: {}", err))?
+  );
+
+  // 对于需要 body 的请求方法，添加请求体
+  if method == reqwest::Method::POST 
+    || method == reqwest::Method::PUT 
+    || method == reqwest::Method::PATCH 
+    || method == reqwest::Method::DELETE {
+    if !body.is_empty() {
+      let body_bytes = bytes::Bytes::from(body);
+      request = request.body(body_bytes);
+    }
+  }
+
+  // 发送请求
+  let response = request.send().await
+    .map_err(|err| {
+      let error_msg = err.source()
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| err.to_string());
+      format!("request failed: {}", error_msg)
+    })?;
+
+  // 获取响应状态和头部
+  let status = response.status().as_u16();
+  let status_text = response.status().canonical_reason()
+    .unwrap_or("Unknown")
+    .to_string();
+
+  let mut response_headers = HashMap::new();
+  for (name, value) in response.headers() {
+    response_headers.insert(
+      name.as_str().to_string(),
+      std::str::from_utf8(value.as_bytes())
+        .unwrap_or("<invalid utf8>")
+        .to_string()
+    );
+  }
+
+  // 读取响应体
+  let response_body = response.bytes().await
+    .map_err(|err| format!("failed to read response body: {}", err))?;
+
+  Ok(FetchResponse {
+    request_id,
+    status,
+    status_text,
+    headers: response_headers,
+    body: response_body.to_vec(),
+  })
+}
+
+#[tauri::command]
+pub async fn http_fetch_text(
+  method: String,
+  url: String,
+  headers: HashMap<String, String>,
+  body: String,
+) -> Result<String, String> {
+  
+  // 将字符串 body 转换为字节
+  let body_bytes = body.into_bytes();
+  
+  // 调用主要的 fetch 方法
+  let response = http_fetch(method, url, headers, body_bytes).await?;
+  
+  // 将响应体转换为字符串
+  let response_text = String::from_utf8(response.body)
+    .map_err(|err| format!("failed to convert response to text: {}", err))?;
+  
+  Ok(response_text)
+}
+
+#[tauri::command]
+pub async fn http_fetch_json(
+  method: String,
+  url: String,
+  headers: HashMap<String, String>,
+  body: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+  
+  // 将 JSON 转换为字符串再转换为字节
+  let body_string = serde_json::to_string(&body)
+    .map_err(|err| format!("failed to serialize JSON body: {}", err))?;
+  let body_bytes = body_string.into_bytes();
+  
+  // 确保设置了正确的 Content-Type
+  let mut json_headers = headers;
+  if !json_headers.contains_key("content-type") && !json_headers.contains_key("Content-Type") {
+    json_headers.insert("Content-Type".to_string(), "application/json".to_string());
+  }
+  
+  // 调用主要的 fetch 方法
+  let response = http_fetch(method, url, json_headers, body_bytes).await?;
+  
+  // 将响应体解析为 JSON
+  let response_json: serde_json::Value = serde_json::from_slice(&response.body)
+    .map_err(|err| format!("failed to parse response as JSON: {}", err))?;
+  
+  Ok(response_json)
+}

--- a/src-tauri/src/fetch.rs
+++ b/src-tauri/src/fetch.rs
@@ -1,5 +1,5 @@
 //
-// 普通 HTTP 请求处理模块
+// HTTP request handler module
 //
 
 use std::time::Duration;
@@ -18,14 +18,6 @@ pub struct FetchResponse {
   status_text: String,
   headers: HashMap<String, String>,
   body: Vec<u8>,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct ErrorResponse {
-  request_id: u32,
-  status: u16,
-  status_text: String,
-  error: String,
 }
 
 #[tauri::command]
@@ -57,11 +49,11 @@ pub async fn http_fetch(
     }
   }
 
-  // 解析 HTTP 方法
+  // Parse HTTP method
   let method = method.parse::<reqwest::Method>()
     .map_err(|err| format!("failed to parse method: {}", err))?;
 
-  // 创建客户端
+  // Create client
   let client = Client::builder()
     .default_headers(_headers)
     .redirect(reqwest::redirect::Policy::limited(3))
@@ -70,14 +62,14 @@ pub async fn http_fetch(
     .build()
     .map_err(|err| format!("failed to create client: {}", err))?;
 
-  // 构建请求
+  // Build request
   let mut request = client.request(
     method.clone(),
     url.parse::<reqwest::Url>()
       .map_err(|err| format!("failed to parse url: {}", err))?
   );
 
-  // 对于需要 body 的请求方法，添加请求体
+  // For request methods that need a body, add the request body
   if method == reqwest::Method::POST 
     || method == reqwest::Method::PUT 
     || method == reqwest::Method::PATCH 
@@ -88,7 +80,7 @@ pub async fn http_fetch(
     }
   }
 
-  // 发送请求
+  // Send request
   let response = request.send().await
     .map_err(|err| {
       let error_msg = err.source()
@@ -97,7 +89,7 @@ pub async fn http_fetch(
       format!("request failed: {}", error_msg)
     })?;
 
-  // 获取响应状态和头部
+  // Get response status and headers
   let status = response.status().as_u16();
   let status_text = response.status().canonical_reason()
     .unwrap_or("Unknown")
@@ -113,7 +105,7 @@ pub async fn http_fetch(
     );
   }
 
-  // 读取响应体
+  // Read response body
   let response_body = response.bytes().await
     .map_err(|err| format!("failed to read response body: {}", err))?;
 
@@ -134,13 +126,13 @@ pub async fn http_fetch_text(
   body: String,
 ) -> Result<String, String> {
   
-  // 将字符串 body 转换为字节
+  // Convert string body to bytes
   let body_bytes = body.into_bytes();
   
-  // 调用主要的 fetch 方法
+  // Call the main fetch method
   let response = http_fetch(method, url, headers, body_bytes).await?;
   
-  // 将响应体转换为字符串
+  // Convert response body to string
   let response_text = String::from_utf8(response.body)
     .map_err(|err| format!("failed to convert response to text: {}", err))?;
   
@@ -155,21 +147,21 @@ pub async fn http_fetch_json(
   body: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
   
-  // 将 JSON 转换为字符串再转换为字节
+  // Convert JSON to string and then to bytes
   let body_string = serde_json::to_string(&body)
     .map_err(|err| format!("failed to serialize JSON body: {}", err))?;
   let body_bytes = body_string.into_bytes();
   
-  // 确保设置了正确的 Content-Type
+  // Ensure the correct Content-Type is set
   let mut json_headers = headers;
   if !json_headers.contains_key("content-type") && !json_headers.contains_key("Content-Type") {
     json_headers.insert("Content-Type".to_string(), "application/json".to_string());
   }
   
-  // 调用主要的 fetch 方法
+  // Call the main fetch method
   let response = http_fetch(method, url, json_headers, body_bytes).await?;
   
-  // 将响应体解析为 JSON
+  // Parse response body as JSON
   let response_json: serde_json::Value = serde_json::from_slice(&response.body)
     .map_err(|err| format!("failed to parse response as JSON: {}", err))?;
   

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,10 +2,16 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod stream;
+mod fetch;
 
 fn main() {
   tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![stream::stream_fetch])
+    .invoke_handler(tauri::generate_handler![
+      stream::stream_fetch,
+      fetch::http_fetch,
+      fetch::http_fetch_text,
+      fetch::http_fetch_json
+    ])
     .plugin(tauri_plugin_window_state::Builder::default().build())
     .run(tauri::generate_context!())
     .expect("error while running tauri application");


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

目前的云端数据同步upstash 不支持 tauri app，所以进行了以下改动 fixes #5617 

1.  增加 fetch.rs 文件，支持 fetch 请求
2. 更改 `app/utils/cloud/upstash.ts` 文件，当检测是 tauri app, 请求路径不再走代理，直接调用 rust 请求
3. 修复 `app/utils/cloud/upstash.ts:158` new URL 传参错误，导致永远进入 catch 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop (Tauri) builds now route network requests through a built-in HTTP bridge with unified fetch-like responses.
  * Bridge exposes text and JSON request/response handling with sensible defaults, redirects, and timeouts.
  * Upstash operations (check/get/set) use the bridge in desktop mode.

* **Bug Fixes**
  * Fixed proxy URL construction to produce valid absolute request paths.
  * Improved header and body handling to prevent request failures and ensure consistent web/desktop routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->