### PR TITLE
fix(sync): Use correct variable for remoteUpdateTime in mergeWithUpdate

### DIFF
--- a/app/utils/sync.ts
+++ b/app/utils/sync.ts
@@ -153,7 +153,7 @@ export function mergeWithUpdate<T extends { lastUpdateTime?: number }>(
   remoteState: T,
 ) {
   const localUpdateTime = localState.lastUpdateTime ?? 0;
-  const remoteUpdateTime = localState.lastUpdateTime ?? 1;
+  const remoteUpdateTime = remoteState.lastUpdateTime ?? 1;
 
   if (localUpdateTime < remoteUpdateTime) {
     merge(remoteState, localState);


### PR DESCRIPTION
## Summary
- Fixed a logic error in `mergeWithUpdate` function where `remoteUpdateTime` was incorrectly assigned from `localState.lastUpdateTime` instead of `remoteState.lastUpdateTime`

## Problem
In `app/utils/sync.ts:156`, the code was:
```typescript
const remoteUpdateTime = localState.lastUpdateTime ?? 1;  // Bug: using localState
```

This caused incorrect merge behavior because the function was comparing `localUpdateTime` with itself (via `localState.lastUpdateTime`), rather than comparing local vs remote timestamps. This could lead to data loss during sync operations.

## Fix
Changed to use the correct variable:
```typescript
const remoteUpdateTime = remoteState.lastUpdateTime ?? 1;  // Fixed: using remoteState
```

## Test plan
- [ ] Verify sync operations correctly compare local and remote update times
- [ ] Confirm data is merged in the correct direction based on timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Bug discovered by [whiterose](https://github.com/shakecodeslikecray/whiterose)