### PR TITLE
fix(security): Remove sensitive auth data from console logs

### DIFF
--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -33,11 +33,7 @@ export function auth(req: NextRequest, modelProvider: ModelProvider) {
   const hashedCode = md5.hash(accessCode ?? "").trim();
 
   const serverConfig = getServerSideConfig();
-  console.log("[Auth] allowed hashed codes: ", [...serverConfig.codes]);
-  console.log("[Auth] got access code:", accessCode);
-  console.log("[Auth] hashed access code:", hashedCode);
-  console.log("[User IP] ", getIP(req));
-  console.log("[Time] ", new Date().toLocaleString());
+  console.log("[Auth] request received at", new Date().toLocaleString());
 
   if (serverConfig.needCode && !serverConfig.codes.has(hashedCode) && !apiKey) {
     return {


### PR DESCRIPTION
## Summary
- Removed logging of sensitive authentication data that could be exposed in server logs

## Problem
In `app/api/auth.ts:33-37`, the following sensitive information was being logged to the console:
- Allowed hashed access codes (full list)
- Raw access codes from requests
- Hashed access codes
- User IP addresses

This is a security risk as these values could be exposed in:
- Server logs
- CI/CD outputs
- Log aggregation systems
- Error monitoring tools

## Fix
Removed all sensitive data logging, keeping only a simple timestamp for debugging:
```typescript
console.log("[Auth] request received at", new Date().toLocaleString());
```

## Test plan
- [ ] Verify auth still works correctly
- [ ] Confirm sensitive data no longer appears in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Bug discovered by [whiterose](https://github.com/shakecodeslikecray/whiterose)