### PR TITLE
Fix #6606: [Bug] 默认google模型中无gemini-2.5-flash

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -560,6 +560,8 @@ const googleModels = [
   "gemini-2.0-flash-thinking-exp-01-21",
   "gemini-2.0-pro-exp",
   "gemini-2.0-pro-exp-02-05",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
   "gemini-2.5-pro-preview-06-05",
   "gemini-2.5-pro"
 ];


### PR DESCRIPTION
Fixes #6606

## Summary
This PR fixes: [Bug] 默认google模型中无gemini-2.5-flash

## Changes
```
app/constant.ts | 2 ++
 1 file changed, 2 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*