### PR TITLE
fix: support provider-filtered 'all' in CUSTOM_MODELS

### DIFF
--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -83,14 +83,18 @@ export function collectModelTable(
         m.startsWith("+") || m.startsWith("-") ? m.slice(1) : m;
       let [name, displayName] = nameConfig.split("=");
 
+      const [customModelName, customProviderName] = getModelProvider(name);
+
       // enable or disable all models
-      if (name === "all") {
-        Object.values(modelTable).forEach(
-          (model) => (model.available = available),
-        );
+      // supports optional @provider filter, e.g. "-all@azure" disables only Azure models
+      if (customModelName === "all") {
+        Object.values(modelTable).forEach((model) => {
+          if (!customProviderName || model.provider?.id === customProviderName) {
+            model.available = available;
+          }
+        });
       } else {
         // 1. find model by name, and set available value
-        const [customModelName, customProviderName] = getModelProvider(name);
         let count = 0;
         for (const fullName in modelTable) {
           const [modelName, providerName] = getModelProvider(fullName);
@@ -113,20 +117,18 @@ export function collectModelTable(
         }
         // 2. if model not exists, create new model with available value
         if (count === 0) {
-          let [customModelName, customProviderName] = getModelProvider(name);
-          const provider = customProvider(
-            customProviderName || customModelName,
-          );
+          let newModelName = customModelName;
+          const provider = customProvider(customProviderName || newModelName);
           // swap name and displayName for bytedance
           if (displayName && provider.providerName == "ByteDance") {
-            [customModelName, displayName] = [displayName, customModelName];
+            [newModelName, displayName] = [displayName, newModelName];
           }
-          modelTable[`${customModelName}@${provider?.id}`] = {
-            name: customModelName,
-            displayName: displayName || customModelName,
+          modelTable[`${newModelName}@${provider?.id}`] = {
+            name: newModelName,
+            displayName: displayName || newModelName,
             available,
-            provider, // Use optional chaining
-            sorted: CustomSeq.next(`${customModelName}@${provider?.id}`),
+            provider,
+            sorted: CustomSeq.next(`${newModelName}@${provider?.id}`),
           };
         }
       }


### PR DESCRIPTION
Fixes #6647

## Problem

When using `CUSTOM_MODELS=-all,+gpt-4.1,+gpt-4o` in a Docker deployment, users unexpectedly see `gpt-4.1 302.AI` and `gpt-4.1 Azure` in the model list alongside `gpt-4.1` (OpenAI). This happens because:

1. `gpt-4.1` exists in `DEFAULT_MODELS` under three providers: OpenAI, Azure (all OpenAI models are mirrored there), and 302.AI
2. `+gpt-4.1` without a provider suffix re-enables `gpt-4.1` for **all** providers after `-all` has disabled them

## Solution

Add support for an `@provider` suffix on the `all` keyword in `CUSTOM_MODELS`, enabling provider-scoped enable/disable operations:

| Syntax | Effect |
|---|---|
| `-all` | Disable all models (existing behavior, unchanged) |
| `-all@azure` | Disable only Azure models |
| `-all@ai302` | Disable only 302.AI models |
| `+all@openai` | Enable only OpenAI models |

Users with the reported issue now have two clean options:

**Option A** – Specify provider explicitly when re-enabling:
```
CUSTOM_MODELS=-all,+gpt-4.1@openai,+gpt-4o@openai
```

**Option B** – Disable unwanted providers after enabling:
```
CUSTOM_MODELS=-all,+gpt-4.1,+gpt-4o,-all@azure,-all@ai302
```

## Changes

- `app/utils/model.ts`: Move `getModelProvider()` call before the `all` check so the provider suffix is parsed in all cases. The `all` branch now filters by `model.provider?.id` when a provider suffix is present.
- Minor refactor: replaced the shadowed inner `let [customModelName, customProviderName]` in the `if (count === 0)` block with `let newModelName = customModelName` to avoid confusing variable re-declaration.

## Testing

Existing behavior is unchanged for `CUSTOM_MODELS` strings that do not use the new `@provider` suffix on `all`. The new `all@provider` feature can be verified manually by setting:
```
CUSTOM_MODELS=-all,+gpt-4.1,-all@azure,-all@ai302
```
and confirming only the OpenAI `gpt-4.1` entry appears in the model selector.