### PR TITLE
fix: add gpt-4.5-preview to vision model detection

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -479,6 +479,7 @@ export const VISION_MODEL_REGEXES = [
   /vision/,
   /gpt-4o/,
   /gpt-4\.1/,
+  /gpt-4\.5/,
   /claude.*[34]/,
   /gemini-1\.5/,
   /gemini-exp/,


### PR DESCRIPTION
## Problem

`gpt-4.5-preview` and `gpt-4.5-preview-2025-02-27` were added to the model list in a previous PR (#6450) but the `VISION_MODEL_REGEXES` in `app/constant.ts` was only updated with the `gpt-4.1` regex — the `gpt-4.5` family was overlooked.

As a result, when a user selects either of these models, the image upload button does not appear in the chat interface, even though both models support multimodal (image) input.

## Solution

Added `/gpt-4\.5/` to `VISION_MODEL_REGEXES` so that `gpt-4.5-preview` and `gpt-4.5-preview-2025-02-27` are correctly identified as vision-capable models and the image upload button is shown.

## Testing

- Verified that `isVisionModel("gpt-4.5-preview")` now returns `true`
- Verified that `isVisionModel("gpt-4.5-preview-2025-02-27")` now returns `true`
- Existing models unaffected: `gpt-4o`, `gpt-4.1`, `gpt-4-turbo-preview` (should still be excluded from vision) all behave correctly