### PR TITLE
fix: skip presence_penalty and frequency_penalty for Grok-3-mini and Grok-4 models

### DIFF
--- a/app/client/platforms/xai.ts
+++ b/app/client/platforms/xai.ts
@@ -76,6 +76,11 @@ export class XAIApi implements LLMApi {
       },
     };
 
+    // Grok-3-mini and Grok-4 models do not support presence_penalty and frequency_penalty
+    const isGrokMiniOrV4 =
+      /grok-3-mini/i.test(modelConfig.model) ||
+      /grok-4/i.test(modelConfig.model);
+
     const requestPayload: RequestPayload = {
       messages,
       stream: options.config.stream,
@@ -85,6 +90,12 @@ export class XAIApi implements LLMApi {
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
     };
+
+    if (isGrokMiniOrV4) {
+      // These models do not accept presence_penalty / frequency_penalty
+      delete (requestPayload as any).presence_penalty;
+      delete (requestPayload as any).frequency_penalty;
+    }
 
     console.log("[Request] xai payload: ", requestPayload);
 


### PR DESCRIPTION
Fixes #6593

## Problem
xAI's `grok-3-mini` and `grok-4` model families do not accept `presence_penalty` and `frequency_penalty` parameters. When NextChat sends requests to these models with the default model config, the xAI API returns an error because these parameters are unsupported.

## Solution
Detect models matching `grok-3-mini` or `grok-4` patterns and remove `presence_penalty` and `frequency_penalty` from the request payload before sending. Other xAI models (e.g., `grok-2`, `grok-beta`) continue to receive these parameters as before.

## Testing
- Configure NextChat with an xAI API key and select `grok-3-mini` or `grok-4` as the model
- Chat should work without API errors related to unsupported parameters
- Other Grok models (grok-2, grok-beta) are unaffected