### PR TITLE
fix: skip top_p for Claude 4 models to avoid API conflict error

### DIFF
--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -179,6 +179,12 @@ export class ClaudeApi implements LLMApi {
       });
     }
 
+    // Claude 4 generation models (claude-opus-4* / claude-sonnet-4*) do not
+    // allow temperature and top_p to be specified simultaneously.
+    const isClaude4 =
+      /claude-opus-4/i.test(modelConfig.model) ||
+      /claude-sonnet-4/i.test(modelConfig.model);
+
     const requestBody: AnthropicChatRequest = {
       messages: prompt,
       stream: shouldStream,
@@ -186,7 +192,7 @@ export class ClaudeApi implements LLMApi {
       model: modelConfig.model,
       max_tokens: modelConfig.max_tokens,
       temperature: modelConfig.temperature,
-      top_p: modelConfig.top_p,
+      top_p: isClaude4 ? undefined : modelConfig.top_p,
       // top_k: modelConfig.top_k,
       top_k: 5,
     };


### PR DESCRIPTION
Fixes #6595

## Problem

Claude 4 generation models (`claude-opus-4*`, `claude-sonnet-4*`) reject requests when both `temperature` and `top_p` are specified simultaneously, returning the error:

```
temperature and top_p cannot both be specified for this model. Please use only one.
```

This affects users who configure custom models like `claude-opus-4.1` through the NextChat interface, since the Anthropic client always includes both parameters in every request.

## Solution

Detect Claude 4 generation models by name pattern and omit `top_p` from the request body when matched. `temperature` is retained as the primary sampling parameter.

This follows the same pattern already used in `app/client/platforms/xai.ts` where `presence_penalty` and `frequency_penalty` are conditionally excluded for Grok-4 models that do not support them.

## Testing

- With a Claude 4 model (e.g. `claude-opus-4.1` or `claude-opus-4-20250514`): request no longer includes `top_p`, resolving the API error
- With older Claude models (e.g. `claude-3-5-sonnet-*`): `top_p` continues to be sent as before